### PR TITLE
Apply page changes for end of recruitment

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,7 +34,7 @@ app.post('/email', (req, res) => {
   const email = req.body.email;
   mailchimp
     .post({
-      path: `/lists/d12b7f1367`,
+      path: `/lists/839cc09118`,
       body: {
         members: [
           {

--- a/server.js
+++ b/server.js
@@ -47,7 +47,7 @@ app.post('/email', (req, res) => {
     .then(result => {
       return res.status(200).json({
         success: true,
-        msg: 'Sucessfully subscribed!'
+        msg: 'Successfully subscribed!'
       });
     })
     .catch(error => {

--- a/src/components/NovaHero.vue
+++ b/src/components/NovaHero.vue
@@ -10,7 +10,7 @@
       <div class="nova-hero-overlay" />
 
     </div>
-    <b-container fluid>
+    <b-container v-if="header || subheader" fluid>
       <text-hero :header="header" :subheader="subheader" />
     </b-container>
   </div>

--- a/src/index.scss
+++ b/src/index.scss
@@ -8,7 +8,7 @@
 @import 'node_modules/bootstrap/scss/navbar';
 @import 'node_modules/bootstrap/scss/forms';
 @import 'node_modules/bootstrap/scss/utilities';
-
+@import 'node_modules/bootstrap/scss/_alert';
 @import './scss/bootstrap-custom/custom';
 
 @import './scss/main';

--- a/src/pages/Apply.vue
+++ b/src/pages/Apply.vue
@@ -1,10 +1,39 @@
 <template class="applyPage">
   <page-background>
-    <nova-hero 
-      :header="Strings.get('join-information.applications-open', 'apply') ? Strings.get('hero.header', 'apply') : Strings.get('hero-closed.header', 'apply')"
-      :subheader="Strings.get('join-information.applications-open', 'apply') ? Strings.get('hero.subheader', 'apply') : Strings.get('hero-closed.subheader', 'apply')"
+    <nova-hero
+      v-if="Strings.get('join-information.applications-open', 'apply')"
+      :header="Strings.get('hero.header', 'apply')"
+      :subheader="Strings.get('hero.subheader', 'apply')"
       page="apply" />
-
+    <nova-hero
+      v-else
+      :header="Strings.get('hero-closed.header', 'apply')"
+      :subheader="Strings.get('hero-closed.subheader', 'apply')"
+      page="apply" />
+    <b-container v-if="!Strings.get('join-information.applications-open', 'apply')" class="email-form">
+      <b-row align-h="center" class="no-gutters">
+        <b-col cols="auto">
+          <h2 class="email-header">Applications are currently closed.</h2>
+          <p>Subscribe to our newsletter to stay updated on the application process.</p>
+        </b-col>
+      </b-row>
+      <b-row align-h="center">
+        <b-alert :show="msgShow" :variant="msgVariant" v-html="msgContent">
+        </b-alert>
+      </b-row>
+      <b-row align-h="center">
+        <b-col cols="auto">
+          <b-form inline @submit="onSubscribe">
+            <b-input-group>
+              <label class="sr-only" for="newsletterEmailSubscribeInput">Email</label>
+              <b-input required id="newsletterEmailSubscribeInput" v-model="email" type="email"
+                placeholder="Email" />
+            </b-input-group>
+            <b-button type="submit">Subscribe</b-button>
+          </b-form>
+        </b-col>
+      </b-row>
+    </b-container>
     <b-row v-if="Strings.get('join-information.applications-open', 'apply')" class="justify-content-center info-session-interjection">
       <b-col class="info-session-description" sm="12" md="4" md-offset="1">
         <div class="header">{{ Strings.get('info-session.header', 'apply') }}</div>
@@ -194,6 +223,20 @@ export default {
 
 .call-to-action-button {
   margin-top: 0.5rem;
+}
+
+.email-form {
+  margin-bottom: 60px;
+
+  .email-header {
+    font-size: 2rem;
+    font-weight: bold;
+    text-align: center;
+
+    & + p {
+      font-size: 1.5rem;
+    }
+  }
 }
 
 .info-session-interjection {

--- a/src/pages/Apply.vue
+++ b/src/pages/Apply.vue
@@ -226,7 +226,8 @@ export default {
 }
 
 .email-form {
-  margin-bottom: 60px;
+  padding-bottom: 3vh;
+  margin-bottom: 4vw;
 
   .email-header {
     font-size: 2rem;

--- a/src/pages/Apply.vue
+++ b/src/pages/Apply.vue
@@ -1,39 +1,35 @@
 <template class="applyPage">
   <page-background>
-    <nova-hero
-      v-if="Strings.get('join-information.applications-open', 'apply')"
-      :header="Strings.get('hero.header', 'apply')"
-      :subheader="Strings.get('hero.subheader', 'apply')"
+    <nova-hero v-if="Strings.get('join-information.applications-open', 'apply')" :header="Strings.get('hero.header', 'apply')"
+      :subheader="Strings.get('hero.subheader', 'apply')" page="apply" />
+    <nova-hero v-else :header="Strings.get('hero-closed.header', 'apply')" :subheader="Strings.get('hero-closed.subheader', 'apply')"
       page="apply" />
-    <nova-hero
-      v-else
-      :header="Strings.get('hero-closed.header', 'apply')"
-      :subheader="Strings.get('hero-closed.subheader', 'apply')"
-      page="apply" />
-    <b-container v-if="!Strings.get('join-information.applications-open', 'apply')" class="email-form">
-      <b-row align-h="center" class="no-gutters">
-        <b-col cols="auto">
-          <h2 class="email-header">Applications are currently closed.</h2>
-          <p>Subscribe to our newsletter to stay updated on the application process.</p>
-        </b-col>
-      </b-row>
-      <b-row align-h="center">
-        <b-alert :show="msgShow" :variant="msgVariant" v-html="msgContent">
-        </b-alert>
-      </b-row>
-      <b-row align-h="center">
-        <b-col cols="auto">
-          <b-form inline @submit="onSubscribe">
-            <b-input-group>
-              <label class="sr-only" for="newsletterEmailSubscribeInput">Email</label>
-              <b-input required id="newsletterEmailSubscribeInput" v-model="email" type="email"
-                placeholder="Email" />
-            </b-input-group>
-            <b-button type="submit">Subscribe</b-button>
-          </b-form>
-        </b-col>
-      </b-row>
-    </b-container>
+    <page-section>
+      <b-container v-if="!Strings.get('join-information.applications-open', 'apply')" class="email-form">
+        <b-row align-h="center" class="no-gutters">
+          <b-col cols="auto">
+            <h2 class="email-header">Applications are currently closed.</h2>
+            <p>Subscribe to our newsletter to stay updated on the application process.</p>
+          </b-col>
+        </b-row>
+        <b-row align-h="center">
+          <b-alert :show="msgShow" :variant="msgVariant" v-html="msgContent">
+          </b-alert>
+        </b-row>
+        <b-row align-h="center">
+          <b-col cols="auto">
+            <b-form inline @submit="onSubscribe">
+              <b-input-group>
+                <label class="sr-only" for="newsletterEmailSubscribeInput">Email</label>
+                <b-input required id="newsletterEmailSubscribeInput" v-model="email" type="email"
+                  placeholder="Email" />
+              </b-input-group>
+              <b-button type="submit">Subscribe</b-button>
+            </b-form>
+          </b-col>
+        </b-row>
+      </b-container>
+    </page-section>
     <b-row v-if="Strings.get('join-information.applications-open', 'apply')" class="justify-content-center info-session-interjection">
       <b-col class="info-session-description" sm="12" md="4" md-offset="1">
         <div class="header">{{ Strings.get('info-session.header', 'apply') }}</div>
@@ -86,7 +82,7 @@
 
     <b-container>
       <role-selector class="application-role-selector" v-model="roleId" dropdownText="I want to apply for..."
-      :centered="true" :bold="true" :showAll="false" />
+        :centered="true" :bold="true" :showAll="false" />
 
       <timeline-section v-for="child of Strings.childrenOf(`application-info.${roleId}`, `apply`)"
         :key="child" :header="Strings.get(`application-info.${roleId}.${child}.header`, `apply`)"
@@ -154,9 +150,7 @@
         </b-row>
         <b-row v-else-if="Strings.get(`application-info.${roleId}.${child}.call-to-action-button-closed.content`, 'apply')">
           <b-col cols="12">
-            <b-button
-              disabled
-              size="lg" variant="secondary" class="call-to-action-button text-center">
+            <b-button disabled size="lg" variant="secondary" class="call-to-action-button text-center">
               {{Strings.get(`application-info.${roleId}.${child}.call-to-action-button-closed.content`,
               'apply')}}
             </b-button>
@@ -226,9 +220,6 @@ export default {
 }
 
 .email-form {
-  padding-bottom: 3vh;
-  margin-bottom: 4vw;
-
   .email-header {
     font-size: 2rem;
     font-weight: bold;

--- a/src/pages/Apply.vue
+++ b/src/pages/Apply.vue
@@ -1,9 +1,11 @@
 <template class="applyPage">
   <page-background>
-    <nova-hero :header="Strings.get('hero.header', 'apply')" :subheader="Strings.get('hero.subheader', 'apply')"
+    <nova-hero 
+      :header="Strings.get('join-information.applications-open', 'apply') ? Strings.get('hero.header', 'apply') : Strings.get('hero-closed.header', 'apply')"
+      :subheader="Strings.get('join-information.applications-open', 'apply') ? Strings.get('hero.subheader', 'apply') : Strings.get('hero-closed.subheader', 'apply')"
       page="apply" />
 
-    <b-row class="justify-content-center info-session-interjection">
+    <b-row v-if="Strings.get('join-information.applications-open', 'apply')" class="justify-content-center info-session-interjection">
       <b-col class="info-session-description" sm="12" md="4" md-offset="1">
         <div class="header">{{ Strings.get('info-session.header', 'apply') }}</div>
         <div class="subheader">{{ Strings.get('info-session.subheader', 'apply') }}</div>
@@ -55,11 +57,11 @@
 
     <b-container>
       <role-selector class="application-role-selector" v-model="roleId" dropdownText="I want to apply for..."
-       :centered="true" :bold="true" :showAll="false" />
+      :centered="true" :bold="true" :showAll="false" />
 
       <timeline-section v-for="child of Strings.childrenOf(`application-info.${roleId}`, `apply`)"
         :key="child" :header="Strings.get(`application-info.${roleId}.${child}.header`, `apply`)"
-        :rightHeader="Strings.get(`application-info.${roleId}.${child}.right-header`, `apply`)">
+        :rightHeader="Strings.get('join-information.applications-open', 'apply') ? Strings.get(`application-info.${roleId}.${child}.right-header`, `apply`) : ''">
 
         <div v-if="Strings.exists(`application-info.${roleId}.${child}.sections.1`, 'apply')"
           v-for="section of Strings.childrenOf(`application-info.${roleId}.${child}.sections`, 'apply')"
@@ -101,7 +103,7 @@
           </b-col>
         </b-row>
 
-        <b-row class="justify-content-center" v-if="Strings.exists(`application-info.${roleId}.${child}.call-to-action-button.content`, 'apply')">
+        <b-row class="justify-content-center" v-if="Strings.get('join-information.applications-open', 'apply') && Strings.exists(`application-info.${roleId}.${child}.call-to-action-button.content`, 'apply')">
           <b-col cols="12">
             <b-row>
               <b-col md="auto" sm="12">
@@ -119,6 +121,16 @@
                 </b-button>
               </b-col>
             </b-row>
+          </b-col>
+        </b-row>
+        <b-row v-else-if="Strings.get(`application-info.${roleId}.${child}.call-to-action-button-closed.content`, 'apply')">
+          <b-col cols="12">
+            <b-button
+              disabled
+              size="lg" variant="secondary" class="call-to-action-button text-center">
+              {{Strings.get(`application-info.${roleId}.${child}.call-to-action-button-closed.content`,
+              'apply')}}
+            </b-button>
           </b-col>
         </b-row>
       </timeline-section>


### PR DESCRIPTION
Resolves #30.

The application season is controlled by a boolean, `join-information.applications-open`. When set to false, the following occurs:

- The two call to action buttons under each role are hidden, and replaced with one button. The content of this new button is pulled from the strings repo.
- The header and subheader changes based on content from the strings repo. 
- Information sessions become totally hidden.
- The application deadline date for each role becomes hidden.