### PR TITLE
eHub Redirect

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -35,6 +35,12 @@ const dtiRouter = new Router({
       component: Home
     },
     {
+      path: '/ehub',
+      redirect: {
+        name: 'Home'
+      }
+    },
+    {
       path: '/Projects/',
       name: 'Projects',
       component: Projects


### PR DESCRIPTION
Redirects from the old eHub Density URL to our homepage. Maybe we can consider redirecting this right to the new Density project page?