### PR TITLE
Inline cloudfront video url

### DIFF
--- a/packages/cdnify-json/index.js
+++ b/packages/cdnify-json/index.js
@@ -54,20 +54,6 @@ module.exports = function cdnify(json, options) {
     }
 }
 
-class CloudFrontProvider {
-    constructor(url) {
-        this._baseUrl = url;
-    }
-
-    transform(url) {
-        return `https://${this._baseUrl}/${url.replace(/^\/public\//, '')}`;
-    }
-}
-
-module.exports.CloudFront = function ({ url }) {
-    return new CloudFrontProvider(url);
-}
-
 module.exports.init = function init(providers) {
     for (const provider of providers) {
         providerMap.set(provider.pattern, provider.provider);

--- a/packages/gridsome-transformer-json-enhanced/index.js
+++ b/packages/gridsome-transformer-json-enhanced/index.js
@@ -1,16 +1,8 @@
 const JSONTransformer = require('@gridsome/transformer-json')
 
 const cdnify = require('cdnify-json');
-const { CloudFront } = cdnify;
 
-cdnify.init([
-    {
-        pattern: /^\/public\/.*\.(webm|m4v|mp4)/g,
-        provider: CloudFront({
-            url: "d2ytxic79evey7.cloudfront.net"
-        }),
-    }
-]);
+cdnify.init([]);
 
 class EnhancedJSONTransformer extends JSONTransformer {
     static mimeTypes() {

--- a/packages/website/build.js
+++ b/packages/website/build.js
@@ -2,17 +2,6 @@
 
 const fs = require('fs');
 const path = require('path');
-const cdnify = require('cdnify-json');
-const { CloudFront } = cdnify;
-
-cdnify.init([
-    {
-        pattern: /^\/public\/.*\.(webm|m4v|mp4)/,
-        provider: CloudFront({
-            url: "d2ytxic79evey7.cloudfront.net"
-        }),
-    }
-]);
 
 function buildMembers() {
     const memberFiles = fs.readdirSync(path.join(__dirname, 'data', 'members'));
@@ -75,42 +64,8 @@ function buildMembers() {
     fs.writeFileSync(outFile, JSON.stringify(members, null, 4));
 }
 
-function buildPages() {
-    const pageFiles = fs.readdirSync(path.join(__dirname, 'data', 'pages'));
-
-    pageFiles
-        .filter(f => f.endsWith(".json"))
-        .map(f => [f, path.join(__dirname, 'data', 'pages', f)])
-        .map(([f, path]) => [f, fs.readFileSync(path, { encoding: 'utf-8' })])
-        .map(([f, contents]) => {
-            try {
-                return [f, JSON.parse(contents)];
-            } catch (err) {
-                console.error(err);
-                return null;
-            }
-        })
-        .filter(([, contents]) => contents != null)
-        .map(([f, contents]) => [f, cdnify(contents)])
-        .forEach(([f, contents]) => {
-            const out = path.join(__dirname, 'data', 'generated', 'pages');
-
-            if (!fs.existsSync(out)) {
-                fs.mkdirSync(out);
-            }
-
-            const outFile = path.join(out, f);
-
-            fs.writeFileSync(outFile, JSON.stringify(contents, null, 2));
-        });
-}
-
 module.exports = function () {
     console.log("Building members...");
     buildMembers();
     console.log("Members built!");
-
-    console.log("Building pages...");
-    buildPages();
-    console.log("Pages built!");
 }

--- a/packages/website/data/pages/apply.json
+++ b/packages/website/data/pages/apply.json
@@ -11,8 +11,8 @@
     "subheader": "In every applicant, we above all look for people that want to use their talents and skills to make a difference. No matter your experience, we also strive to be as inclusive as possible and give passionate people a chance to grow and learn with us.",
     "lazy": "/static/pages/apply-hero-lazy.jpg",
     "video": {
-      "webm": "/public/pages/apply/hero/hero.webm",
-      "mp4": "/public/pages/apply/hero/hero.mp4"
+      "webm": "https://d2ytxic79evey7.cloudfront.net/pages/apply/hero/hero.webm",
+      "mp4": "https://d2ytxic79evey7.cloudfront.net/pages/apply/hero/hero.mp4"
     },
     "image": "/static/pages/apply-hero.png"
   },

--- a/packages/website/data/pages/home.json
+++ b/packages/website/data/pages/home.json
@@ -6,8 +6,8 @@
   "hero": {
     "lazy": "/static/pages/home-hero-lazy.jpg",
     "video": {
-      "mp4": "/public/pages/home/hero/hero.mp4",
-      "webm": "/public/pages/home/hero/hero.webm"
+      "mp4": "https://d2ytxic79evey7.cloudfront.net/pages/home/hero/hero.mp4",
+      "webm": "https://d2ytxic79evey7.cloudfront.net/pages/home/hero/hero.webm"
     },
     "image": "/static/pages/home-hero.png"
   },

--- a/packages/website/data/pages/initiatives.json
+++ b/packages/website/data/pages/initiatives.json
@@ -2,8 +2,8 @@
   "hero": {
     "lazy": "/static/pages/initiatives-hero-lazy.jpg",
     "video": {
-      "mp4": "/public/pages/initiatives/hero/hero.mp4",
-      "webm": "/public/pages/initiatives/hero/hero.webm"
+      "mp4": "https://d2ytxic79evey7.cloudfront.net/pages/initiatives/hero/hero.mp4",
+      "webm": "https://d2ytxic79evey7.cloudfront.net/pages/initiatives/hero/hero.webm"
     },
     "image": "/static/pages/initiatives-hero.png"
   },

--- a/packages/website/data/pages/projects.json
+++ b/packages/website/data/pages/projects.json
@@ -4,8 +4,8 @@
     "subheader": "We've learned that tackling the hardest problems is the only way to truly create value for the people around us. Each of our projects address an unfulfilled need that exists in our community using human-centered design and software engineering.",
     "lazy": "/static/pages/projects-hero-lazy.jpg",
     "video": {
-      "mp4": "/public/pages/projects/hero/hero.mp4",
-      "webm": "/public/pages/projects/hero/hero.webm"
+      "mp4": "https://d2ytxic79evey7.cloudfront.net/pages/projects/hero/hero.mp4",
+      "webm": "https://d2ytxic79evey7.cloudfront.net/pages/projects/hero/hero.webm"
     },
     "image": "/static/pages/projects-hero.png"
   },

--- a/packages/website/data/pages/team.json
+++ b/packages/website/data/pages/team.json
@@ -4,8 +4,8 @@
     "subheader": "We are Cornell Design & Tech Initiative. But individually, we are a talented, diverse group of students from different colleges and countries striving to make a difference in our community.",
     "lazy": "/static/pages/team-hero-lazy.jpg",
     "video": {
-      "mp4": "/public/pages/team/hero/hero.mp4",
-      "webm": "/public/pages/team/hero/hero.webm"
+      "mp4": "https://d2ytxic79evey7.cloudfront.net/pages/team/hero/hero.mp4",
+      "webm": "https://d2ytxic79evey7.cloudfront.net/pages/team/hero/hero.webm"
     },
     "image": "/static/pages/team-hero.png"
   },

--- a/packages/website/gridsome.config.js
+++ b/packages/website/gridsome.config.js
@@ -76,56 +76,56 @@ module.exports = {
       use: '@gridsome/source-filesystem',
       options: {
         typeName: 'HomeEntry',
-        path: './data/generated/pages/home.json',
+        path: './data/pages/home.json',
       },
     },
     {
       use: '@gridsome/source-filesystem',
       options: {
         typeName: 'TeamEntry',
-        path: './data/generated/pages/team.json',
+        path: './data/pages/team.json',
       },
     },
     {
       use: '@gridsome/source-filesystem',
       options: {
         typeName: 'CoursesEntry',
-        path: './data/generated/pages/courses.json',
+        path: './data/pages/courses.json',
       },
     },
     {
       use: '@gridsome/source-filesystem',
       options: {
         typeName: 'InitiativesEntry',
-        path: './data/generated/pages/initiatives.json',
+        path: './data/pages/initiatives.json',
       },
     },
     {
       use: '@gridsome/source-filesystem',
       options: {
         typeName: 'ProjectsEntry',
-        path: './data/generated/pages/projects.json',
+        path: './data/pages/projects.json',
       },
     },
     {
       use: '@gridsome/source-filesystem',
       options: {
         typeName: 'PrivacyEntry',
-        path: './data/generated/pages/privacy.json',
+        path: './data/pages/privacy.json',
       },
     },
     {
       use: '@gridsome/source-filesystem',
       options: {
         typeName: 'SponsorEntry',
-        path: './data/generated/pages/sponsor.json',
+        path: './data/pages/sponsor.json',
       },
     },
     {
       use: '@gridsome/source-filesystem',
       options: {
         typeName: 'ApplyEntry',
-        path: './data/generated/pages/apply.json',
+        path: './data/pages/apply.json',
       },
     },
     {


### PR DESCRIPTION
The current path in the config json already points to non-existing local files. Keep those links and then apply a transformation doesn't make sense. Let's inline the correct URLs directly without an extra build step.