### PR TITLE
Eliminate the need of build:grid

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Yarn Install
         run: yarn install
       - name: Build
-        run: yarn build
+        run: yarn workspace website build
       - name: Upload Built Static Assets
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,8 +1,5 @@
 name: CI
 on: push
-env:
-  NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-  NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
 jobs:
   check:
@@ -14,4 +11,4 @@ jobs:
       - name: Yarn Install
         run: yarn install
       - name: Run Linter
-        run: yarn lint
+        run: yarn workspace website lint

--- a/.github/workflows/ci-previews.yml
+++ b/.github/workflows/ci-previews.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Yarn Install
         run: yarn install
       - name: Build
-        run: yarn build
+        run: yarn workspace website build
       - name: Deploy to Netlify
         run: |
           ./packages/website/node_modules/.bin/netlify deploy --json > a.json

--- a/package.json
+++ b/package.json
@@ -1,9 +1,5 @@
 {
   "private": true,
-  "scripts": {
-    "build": "yarn workspace website build",
-    "lint": "yarn workspace website lint"
-  },
   "workspaces": {
     "packages": [
       "packages/*"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.1",
   "scripts": {
-    "build": "yarn build:lib && yarn build:grid && yarn build:grid",
+    "build": "yarn gen && yarn build:lib && yarn build:grid",
     "build:grid": "gridsome build",
     "build:lib": "vue-cli-service build --target lib --name dti-nova --formats commonjs --dest admin/lib src/lib.ts",
     "serve": "gridsome develop",


### PR DESCRIPTION
It turns out the reason we need double `build:grid` is that the first build calls `yarn gen` that produces the generated folder for gridsome to consume. We can avoid that by running a cheap `yarn gen` before `yarn build:grid`. Now we can cut the build step time of preview by 1/3.