### PR TITLE
Small member json fixes

### DIFF
--- a/packages/website/data/members/ec592.json
+++ b/packages/website/data/members/ec592.json
@@ -10,8 +10,9 @@
     "linkedin": "https://www.linkedin.com/in/emilychan-21/",
     "hometown": "Millburn, NJ",
     "about": "Hello! I'm Emily and I'm a product designer, nature lover, and meme enthusiast. When I'm not hanging out in Duffield or designing something with too many gradients, catch me rock climbing, hiking, cooking, playing guitar, or looking at cute otters on Instagram.",
-    "subteam": "Leads",
+    "subteam": "courseplan",
     "otherSubteams": [
+        "Leads",
         "researchconnect"
     ],
     "roleId": "lead",

--- a/packages/website/data/members/ew469.json
+++ b/packages/website/data/members/ew469.json
@@ -13,7 +13,7 @@
     "otherSubteams": [
         "flux",
         "shout",
-        "website"
+        "nova"
     ],
     "roleId": "lead",
     "roleDescription": "Lead",

--- a/packages/website/data/members/klx2.json
+++ b/packages/website/data/members/klx2.json
@@ -12,7 +12,7 @@
     "about": "I'm a junior double majoring in Information Science and Applied Economics and Management. I'm happiest when I'm creating, whether that be writing a story, knitting a scarf or drawing. I'm currently a part of DTI (obviously), Cornell Ascend, and Shogi Club. When I'm not trying to power through all my work, you can find me drinking boba tea, watching anime, or obsessing over my betta fish.",
     "subteam": "business",
     "otherSubteams": [
-        "website",
+        "nova",
         "carriage",
         "courseplan"
     ],

--- a/packages/website/data/members/ss2629.json
+++ b/packages/website/data/members/ss2629.json
@@ -12,7 +12,7 @@
     "about": "I'm an aspiring product/UX designer and I hope to make a positive, social impact through the field of design. Besides designing, I love all things music and dance! On campus, I am a member of Cornell Anjali, an Indian classical dance team, and a member of Forté Campus at Cornell, a professional business organization. In my free time, I enjoy exploring new places to eat and drink coffee, finding fun things to take pictures of, and learning how to play my favorite songs on the piano.",
     "subteam": "samwise",
     "otherSubteams": [
-        "website"
+        "nova"
     ],
     "roleId": "designer",
     "roleDescription": "Designer"

--- a/packages/website/data/members/wes229.json
+++ b/packages/website/data/members/wes229.json
@@ -12,7 +12,7 @@
     "about": "Hey! I'm Will, a sophomore developer on DTI, and I love to spend my time coding and helping out the community. Besides DTI, I am involved with Girls Who Code on campus, where I help high-school students learn and appreciate the basics of programming. Besides developing, I spend my time gaming and following politics, so I can commonly be found yelling at my computer due to a broken controller or some scandalous news story.",
     "subteam": "courseplan",
     "otherSubteams": [
-        "website"
+        "nova"
     ],
     "roleId": "pm",
     "roleDescription": "Technical PM"

--- a/packages/website/data/members/yc686.json
+++ b/packages/website/data/members/yc686.json
@@ -13,7 +13,7 @@
     "subteam": "flux",
     "otherSubteams": [
         "reviews",
-        "website"
+        "nova"
     ],
     "roleId": "pm",
     "roleDescription": "Product Manager"


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request makes a few small fixes to member jsons.

- [x] Adds Emily Chan back to CoursePlan
- [x] Add "website" back to the appropriate old team members

### Test Plan <!-- Required -->

Ensure that Emily shows on the CoursePlan page and that "Website" shows up for the old team members (me, Evan, Ishika, etc.) in their modals.
