### PR TITLE
Get rid of '@' path mapping.

### DIFF
--- a/packages/website/.eslintrc.js
+++ b/packages/website/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
       'always',
       {
         ts: 'never',
+        tsx: 'never',
         'd.ts': 'never',
         js: 'never'
       }

--- a/packages/website/src/App.vue
+++ b/packages/website/src/App.vue
@@ -8,8 +8,8 @@
 <style src="bootstrap-vue/dist/bootstrap-vue.css"></style>
 
 <script script="ts">
-import EventBus from '@/eventbus';
-import DtiMainMenu from '@/components/DtiMainMenu.vue';
+import EventBus from './eventbus';
+import DtiMainMenu from './components/DtiMainMenu.vue';
 
 export default {
   name: 'App',

--- a/packages/website/src/components/CircleProgressIndicator.vue
+++ b/packages/website/src/components/CircleProgressIndicator.vue
@@ -25,7 +25,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import DonutGraph from './DonutGraph.tsx';
+import DonutGraph from './DonutGraph';
 
 export default Vue.extend({
   components: {

--- a/packages/website/src/components/CircleProgressIndicator.vue
+++ b/packages/website/src/components/CircleProgressIndicator.vue
@@ -25,7 +25,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import DonutGraph from '@/components/DonutGraph.tsx';
+import DonutGraph from './DonutGraph.tsx';
 
 export default Vue.extend({
   components: {

--- a/packages/website/src/components/DtiFooter.vue
+++ b/packages/website/src/components/DtiFooter.vue
@@ -121,16 +121,16 @@ import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 import { BModal } from 'bootstrap-vue';
 
-import Facebook from '@/assets/social/facebook.svg';
-import Dribbble from '@/assets/social/dribbble.svg';
-import Github from '@/assets/social/github.svg';
-import GooglePlay from '@/assets/social/google-play.svg';
-import AppStore from '@/assets/social/app-store.svg';
-import Medium from '@/assets/social/medium.svg';
-import Heart from '@/assets/footer/heart.svg';
-import HeartMobile from '@/assets/footer/heart-mobile.svg';
+import Facebook from '../assets/social/facebook.svg';
+import Dribbble from '../assets/social/dribbble.svg';
+import Github from '../assets/social/github.svg';
+import GooglePlay from '../assets/social/google-play.svg';
+import AppStore from '../assets/social/app-store.svg';
+import Medium from '../assets/social/medium.svg';
+import Heart from '../assets/footer/heart.svg';
+import HeartMobile from '../assets/footer/heart-mobile.svg';
 
-import MailChimpForm from '@/components/MailChimpForm.vue';
+import MailChimpForm from './MailChimpForm.vue';
 
 @Component({
   components: {

--- a/packages/website/src/components/DtiMainMenu.vue
+++ b/packages/website/src/components/DtiMainMenu.vue
@@ -112,7 +112,7 @@ query {
 </static-query>
 
 <script>
-import EventBus from '@/eventbus';
+import EventBus from '../eventbus';
 
 export default {
   data() {

--- a/packages/website/src/components/HeadshotCard.vue
+++ b/packages/website/src/components/HeadshotCard.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script>
-import MissingImage from '@/assets/other/missing.svg';
+import MissingImage from '../assets/other/missing.svg';
 
 export default {
   components: {

--- a/packages/website/src/components/HeadshotGrid.vue
+++ b/packages/website/src/components/HeadshotGrid.vue
@@ -29,10 +29,10 @@
 import { BModal } from 'bootstrap-vue';
 
 import Vue from 'vue';
-import HeadshotCard from '@/components/HeadshotCard.vue';
-import MemberProfileModal from '@/components/MemberProfileModal.vue';
+import HeadshotCard from './HeadshotCard.vue';
+import MemberProfileModal from './MemberProfileModal.vue';
 
-import { Member } from '@/shared';
+import { Member } from '../shared';
 
 type MemberInfo = { id: string; info: Member };
 

--- a/packages/website/src/components/MemberProfileModal.vue
+++ b/packages/website/src/components/MemberProfileModal.vue
@@ -139,12 +139,12 @@ import Vue from 'vue';
 import { Component, Watch } from 'vue-property-decorator';
 
 import { BModal } from 'bootstrap-vue';
-import { ObjectProp, BooleanProp } from '@/util/common';
+import { ObjectProp, BooleanProp } from '../util/common';
 
-import Github from '@/assets/social/github.svg';
-import LinkedIn from '@/assets/social/linkedin.svg';
-import MissingImage from '@/assets/other/missing.svg';
-import { Member } from '@/shared';
+import Github from '../assets/social/github.svg';
+import LinkedIn from '../assets/social/linkedin.svg';
+import MissingImage from '../assets/other/missing.svg';
+import { Member } from '../shared';
 
 @Component({
   components: {

--- a/packages/website/src/components/NovaHero.vue
+++ b/packages/website/src/components/NovaHero.vue
@@ -53,7 +53,7 @@ $height: 65vh;
 
 <script lang="ts">
 import Vue from 'vue';
-import LazyVideo from '@/components/LazyVideo.tsx';
+import LazyVideo from './LazyVideo';
 
 export default Vue.extend({
   components: { LazyVideo },

--- a/packages/website/src/components/ProjectFeaturesList.vue
+++ b/packages/website/src/components/ProjectFeaturesList.vue
@@ -39,7 +39,8 @@
 <script lang="ts">
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
-import { Project } from '@/shared';
+
+import { Project } from '../shared';
 
 export default Vue.extend({
   props: {

--- a/packages/website/src/components/ProjectGoTo.vue
+++ b/packages/website/src/components/ProjectGoTo.vue
@@ -78,10 +78,10 @@
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
 
-import { Project } from '@/shared';
+import { Project } from '../shared';
 
-import StoreBadge from '@/components/StoreBadge.vue';
-import Github from '@/assets/social/github.svg';
+import StoreBadge from './StoreBadge.vue';
+import Github from '../assets/social/github.svg';
 
 export default Vue.extend({
   components: {

--- a/packages/website/src/components/ProjectHeader.vue
+++ b/packages/website/src/components/ProjectHeader.vue
@@ -30,8 +30,9 @@
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
 
-import ProjectGoTo from '@/components/ProjectGoTo.vue';
-import { Project } from '@/shared';
+import ProjectGoTo from './ProjectGoTo.vue';
+
+import { Project } from '../shared';
 
 export default Vue.extend({
   components: { ProjectGoTo },

--- a/packages/website/src/components/ProjectLearnMore.vue
+++ b/packages/website/src/components/ProjectLearnMore.vue
@@ -71,10 +71,10 @@
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
 
-import { Project } from '@/shared';
+import { Project } from '../shared';
 
-import Github from '@/assets/social/github.svg';
-import Medium from '@/assets/social/medium.svg';
+import Github from '../assets/social/github.svg';
+import Medium from '../assets/social/medium.svg';
 
 export default Vue.extend({
   components: {

--- a/packages/website/src/components/StoreBadge.vue
+++ b/packages/website/src/components/StoreBadge.vue
@@ -8,8 +8,8 @@
 </template>
 
 <script>
-import AppStoreBadge from '@/assets/stores/app-store.svg';
-import GooglePlayBadge from '@/assets/stores/google-play.svg';
+import AppStoreBadge from '../assets/stores/app-store.svg';
+import GooglePlayBadge from '../assets/stores/google-play.svg';
 
 export default {
   components: { AppStoreBadge, GooglePlayBadge },

--- a/packages/website/src/components/TeamMembers.vue
+++ b/packages/website/src/components/TeamMembers.vue
@@ -15,8 +15,8 @@
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
 
-import HeadshotGrid from '@/components/HeadshotGrid.vue';
-import { Member } from '@/shared';
+import HeadshotGrid from './HeadshotGrid.vue';
+import { Member } from '../shared';
 
 type MemberInfo = { info: Member; id: string };
 

--- a/packages/website/src/components/TextPageHero.vue
+++ b/packages/website/src/components/TextPageHero.vue
@@ -25,7 +25,7 @@
 </style>
 
 <script>
-import PageHero from '@/components/PageHero.vue';
+import PageHero from './PageHero.vue';
 
 export default {
   extends: PageHero,

--- a/packages/website/src/lib.ts
+++ b/packages/website/src/lib.ts
@@ -4,26 +4,26 @@
 import './webpackConfig';
 
 import { VueConstructor } from 'vue';
-import Apply from '@/views/Apply.vue';
-import Courses from '@/views/Courses.vue';
-import Home from '@/views/Home.vue';
-import Initiatives from '@/views/Initiatives.vue';
-import Projects from '@/views/Projects.vue';
-import Sponsor from '@/views/Sponsor.vue';
-import TeamView from '@/views/Team.vue';
+import Apply from './views/Apply.vue';
+import Courses from './views/Courses.vue';
+import Home from './views/Home.vue';
+import Initiatives from './views/Initiatives.vue';
+import Projects from './views/Projects.vue';
+import Sponsor from './views/Sponsor.vue';
+import TeamView from './views/Team.vue';
 
-import DtiFooter from '@/components/DtiFooter.vue';
-import PageBackground from '@/components/PageBackground.vue';
-import PageHero from '@/components/PageHero.vue';
-import NovaHero from '@/components/NovaHero.vue';
-import PageSublist from '@/components/PageSublist.vue';
-import TextPageHero from '@/components/TextPageHero.vue';
-import TextHero from '@/components/TextHero.vue';
-import PageSection from '@/components/PageSection.vue';
-import MemberProfileModal from '@/components/MemberProfileModal.vue';
-import DTIProject from '@/templates/DTIProject.vue';
+import DtiFooter from './components/DtiFooter.vue';
+import PageBackground from './components/PageBackground.vue';
+import PageHero from './components/PageHero.vue';
+import NovaHero from './components/NovaHero.vue';
+import PageSublist from './components/PageSublist.vue';
+import TextPageHero from './components/TextPageHero.vue';
+import TextHero from './components/TextHero.vue';
+import PageSection from './components/PageSection.vue';
+import MemberProfileModal from './components/MemberProfileModal.vue';
+import DTIProject from './templates/DTIProject.vue';
 
-import { initializeVue } from '@/shared';
+import { initializeVue } from './shared';
 
 const Components = {
   Apply,

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -2,19 +2,19 @@ import { VueConstructor } from 'vue';
 import VueRouter from 'vue-router';
 import 'vue-meta';
 
-import DtiFooter from '@/components/DtiFooter.vue';
-import Give from '@/components/Give';
-import PageBackground from '@/components/PageBackground.vue';
-import PageHero from '@/components/PageHero.vue';
-import NovaHero from '@/components/NovaHero.vue';
-import PageSublist from '@/components/PageSublist.vue';
-import TextPageHero from '@/components/TextPageHero.vue';
-import TextHero from '@/components/TextHero.vue';
-import PageSection from '@/components/PageSection.vue';
+import DtiFooter from './components/DtiFooter.vue';
+import Give from './components/Give';
+import PageBackground from './components/PageBackground.vue';
+import PageHero from './components/PageHero.vue';
+import NovaHero from './components/NovaHero.vue';
+import PageSublist from './components/PageSublist.vue';
+import TextPageHero from './components/TextPageHero.vue';
+import TextHero from './components/TextHero.vue';
+import PageSection from './components/PageSection.vue';
 
-import DTIProject from '@/templates/DTIProject.vue';
+import DTIProject from './templates/DTIProject.vue';
 
-import { initializeVue } from '@/shared';
+import { initializeVue } from './shared';
 
 import CompaniesJSON from '../data/sets/companies.json';
 import TeamsJSON from '../data/sets/teams.json';

--- a/packages/website/src/pages/Apply.vue
+++ b/packages/website/src/pages/Apply.vue
@@ -5,10 +5,10 @@
 <script lang="ts">
 import { Component } from 'vue-property-decorator';
 
-import ApplyView from '@/views/Apply.vue';
-import Page from '@/page';
+import ApplyView from '../views/Apply.vue';
+import Page from '../page';
 
-import { ApplyContent } from '@/content';
+import { ApplyContent } from '../content';
 
 import json from '../../data/pages/apply.json';
 

--- a/packages/website/src/pages/Courses.vue
+++ b/packages/website/src/pages/Courses.vue
@@ -5,10 +5,10 @@
 <script lang="ts">
 import { Component } from 'vue-property-decorator';
 
-import CoursesView from '@/views/Courses.vue';
-import Page from '@/page';
+import CoursesView from '../views/Courses.vue';
+import Page from '../page';
 
-import { CoursesContent } from '@/content';
+import { CoursesContent } from '../content';
 
 import json from '../../data/pages/courses.json';
 

--- a/packages/website/src/pages/Index.vue
+++ b/packages/website/src/pages/Index.vue
@@ -5,10 +5,10 @@
 <script lang="ts">
 import { Component } from 'vue-property-decorator';
 
-import HomeView from '@/views/Home.vue';
-import Page from '@/page';
+import HomeView from '../views/Home.vue';
+import Page from '../page';
 
-import { HomeContent } from '@/content';
+import { HomeContent } from '../content';
 
 import json from '../../data/pages/home.json';
 

--- a/packages/website/src/pages/Initiatives.vue
+++ b/packages/website/src/pages/Initiatives.vue
@@ -5,10 +5,10 @@
 <script lang="ts">
 import { Component } from 'vue-property-decorator';
 
-import InitiativesView from '@/views/Initiatives.vue';
-import Page from '@/page';
+import InitiativesView from '../views/Initiatives.vue';
+import Page from '../page';
 
-import { InitiativesContent } from '@/content';
+import { InitiativesContent } from '../content';
 
 import json from '../../data/pages/initiatives.json';
 

--- a/packages/website/src/pages/Privacy.vue
+++ b/packages/website/src/pages/Privacy.vue
@@ -19,12 +19,12 @@ query Privacy {
 <script lang="ts">
 import { Component } from 'vue-property-decorator';
 
-import PrivacyView from '@/views/Privacy.vue';
+import PrivacyView from '../views/Privacy.vue';
 
-import EventBus from '@/eventbus';
-import Page from '@/page';
+import EventBus from '../eventbus';
+import Page from '../page';
 
-import { PrivacyContent, PrivacyPolicy } from '@/content';
+import { PrivacyContent, PrivacyPolicy } from '../content';
 
 import json from '../../data/pages/privacy.json';
 

--- a/packages/website/src/pages/Projects.vue
+++ b/packages/website/src/pages/Projects.vue
@@ -20,12 +20,12 @@ query DTIProjects {
 <script lang="ts">
 import { Component } from 'vue-property-decorator';
 
-import ProjectsView from '@/views/Projects.vue';
+import ProjectsView from '../views/Projects.vue';
 
-import Page from '@/page';
+import Page from '../page';
 
-import { ProjectsContent } from '@/content';
-import { Member, Project } from '@/shared';
+import { ProjectsContent } from '../content';
+import { Member, Project } from '../shared';
 
 import json from '../../data/pages/projects.json';
 

--- a/packages/website/src/pages/Sponsor.vue
+++ b/packages/website/src/pages/Sponsor.vue
@@ -5,10 +5,10 @@
 <script lang="ts">
 import { Component } from 'vue-property-decorator';
 
-import SponsorView from '@/views/Sponsor.vue';
-import Page from '@/page';
+import SponsorView from '../views/Sponsor.vue';
+import Page from '../page';
 
-import { SponsorContent } from '@/content';
+import { SponsorContent } from '../content';
 
 import json from '../../data/pages/sponsor.json';
 

--- a/packages/website/src/pages/Team.vue
+++ b/packages/website/src/pages/Team.vue
@@ -32,15 +32,15 @@ query Members {
 <script lang="ts">
 import { Component } from 'vue-property-decorator';
 
-import TeamView from '@/views/Team.vue';
+import TeamView from '../views/Team.vue';
 
-import { Member } from '@/shared';
+import { Member } from '../shared';
 
-import Page from '@/page';
+import Page from '../page';
 
-import { TeamContent } from '@/content';
+import { TeamContent } from '../content';
 
-import DiversityJSON from '@/../data/sets/diversity.json';
+import DiversityJSON from '../../data/sets/diversity.json';
 
 import json from '../../data/pages/team.json';
 

--- a/packages/website/src/templates/DTIProject.vue
+++ b/packages/website/src/templates/DTIProject.vue
@@ -117,13 +117,13 @@ query DTIProjects ($path: String!, $teamId: String!) {
 <script lang="ts">
 import Vue from 'vue';
 
-import EventBus from '@/eventbus';
-import ProjectFeaturesList from '@/components/ProjectFeaturesList.vue';
-import ProjectLearnMore from '@/components/ProjectLearnMore.vue';
-import ProjectHeader from '@/components/ProjectHeader.vue';
-import TeamMembers from '@/components/TeamMembers.vue';
+import EventBus from '../eventbus';
+import ProjectFeaturesList from '../components/ProjectFeaturesList.vue';
+import ProjectLearnMore from '../components/ProjectLearnMore.vue';
+import ProjectHeader from '../components/ProjectHeader.vue';
+import TeamMembers from '../components/TeamMembers.vue';
 
-import { Member, Project } from '@/shared';
+import { Member, Project } from '../shared';
 
 type EdgeNode<T> = { edges: { node: T }[] };
 

--- a/packages/website/src/views/Apply.vue
+++ b/packages/website/src/views/Apply.vue
@@ -187,11 +187,11 @@
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
 
-import TimelineSection from '@/components/TimelineSection.vue';
-import RoleSelector from '@/components/RoleSelector.vue';
-import DtiFooter from '@/components/DtiFooter.vue';
+import TimelineSection from '../components/TimelineSection.vue';
+import RoleSelector from '../components/RoleSelector.vue';
+import DtiFooter from '../components/DtiFooter.vue';
 
-import { ApplyContent, ApplicationInfo } from '@/content';
+import { ApplyContent, ApplicationInfo } from '../content';
 
 interface Apply {
   $refs: {

--- a/packages/website/src/views/Courses.vue
+++ b/packages/website/src/views/Courses.vue
@@ -252,10 +252,10 @@ $dark-gray: #4a4a4a;
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
 
-import GitHubIcon from '@/assets/social/github.svg';
-import ApplyIcon from '@/assets/other/apply.svg';
+import GitHubIcon from '../assets/social/github.svg';
+import ApplyIcon from '../assets/other/apply.svg';
 
-import { CoursesContent } from '@/content';
+import { CoursesContent } from '../content';
 
 export default Vue.extend({
   props: {

--- a/packages/website/src/views/Home.vue
+++ b/packages/website/src/views/Home.vue
@@ -46,8 +46,9 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
+
 import Quicklink from '../components/Quicklink.vue';
-import LazyVideo from '../components/LazyVideo.tsx';
+import LazyVideo from '../components/LazyVideo';
 
 import { HomeContent } from '../content';
 

--- a/packages/website/src/views/Home.vue
+++ b/packages/website/src/views/Home.vue
@@ -46,10 +46,10 @@
 <script lang="ts">
 import Vue from 'vue';
 import { Component, Prop } from 'vue-property-decorator';
-import Quicklink from '@/components/Quicklink.vue';
-import LazyVideo from '@/components/LazyVideo.tsx';
+import Quicklink from '../components/Quicklink.vue';
+import LazyVideo from '../components/LazyVideo.tsx';
 
-import { HomeContent } from '@/content';
+import { HomeContent } from '../content';
 
 @Component({
   components: {

--- a/packages/website/src/views/Initiatives.vue
+++ b/packages/website/src/views/Initiatives.vue
@@ -273,10 +273,10 @@ $dark-gray: #4a4a4a;
 <script lang="ts">
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
-import FacebookIcon from '@/assets/social/facebook-white.svg';
-import MediumIcon from '@/assets/social/medium-white-m.svg';
+import FacebookIcon from '../assets/social/facebook-white.svg';
+import MediumIcon from '../assets/social/medium-white-m.svg';
 
-import { InitiativesContent } from '@/content';
+import { InitiativesContent } from '../content';
 
 export default Vue.extend({
   props: {

--- a/packages/website/src/views/Privacy.vue
+++ b/packages/website/src/views/Privacy.vue
@@ -30,7 +30,7 @@
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
 
-import { PrivacyContent, PrivacyPolicy } from '@/content';
+import { PrivacyContent, PrivacyPolicy } from '../content';
 
 export default Vue.extend({
   props: {

--- a/packages/website/src/views/Projects.vue
+++ b/packages/website/src/views/Projects.vue
@@ -69,8 +69,8 @@
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
 
-import { ProjectsContent } from '@/content';
-import { Project } from '@/shared';
+import { ProjectsContent } from '../content';
+import { Project } from '../shared';
 
 export default Vue.extend({
   props: {

--- a/packages/website/src/views/Sponsor.vue
+++ b/packages/website/src/views/Sponsor.vue
@@ -158,9 +158,9 @@
 <script lang="ts">
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
-import wcheck from '@/assets/sponsor/whitecheck.svg';
+import wcheck from '../assets/sponsor/whitecheck.svg';
 
-import { SponsorContent, SponsorTier } from '@/content';
+import { SponsorContent, SponsorTier } from '../content';
 
 type SponsorTierBenefitsData = {
   benefits: string;

--- a/packages/website/src/views/Team.vue
+++ b/packages/website/src/views/Team.vue
@@ -385,12 +385,12 @@ $secondary: #f6f6f6;
 <script lang="ts">
 import Vue from 'vue';
 import { PropValidator } from 'vue/types/options';
-import HeadshotGrid from '@/components/HeadshotGrid.vue';
-import RoleSelector from '@/components/RoleSelector.vue';
-import CircleProgressIndicator from '@/components/CircleProgressIndicator.vue';
+import HeadshotGrid from '../components/HeadshotGrid.vue';
+import RoleSelector from '../components/RoleSelector.vue';
+import CircleProgressIndicator from '../components/CircleProgressIndicator.vue';
 
-import { TeamContent } from '@/content';
-import { Member } from '@/shared';
+import { TeamContent } from '../content';
+import { Member } from '../shared';
 
 type RoleId = '' | 'business' | 'developer' | 'designer' | 'pm';
 

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -14,11 +14,6 @@
     "types": [
       "webpack-env"
     ],
-    "paths": {
-      "@/*": [
-        "src/*"
-      ]
-    },
     "lib": [
       "esnext",
       "dom",


### PR DESCRIPTION
In the original Vue template this project was based off of (and most `vue-cli` v2 projects) the path mapping `@` to `./src` was included by default.

This became more challenging to support when using Typescript and `vue-cli` v4 and moving forward it isn't worth the effort - we have a fairly flat structure and file paths are easier to read/better supported by most IDEs.

Let's remove it.