### PR TITLE
Use <g-link> instead of <b-link> and <router-link>.

### DIFF
--- a/packages/website/src/components/DtiFooter.vue
+++ b/packages/website/src/components/DtiFooter.vue
@@ -50,7 +50,6 @@
                 </b-col>
                 <b-col cols="auto" class="social-icon-wrapper">
                   <a href="http://appstore.com/cornelldti">
-                    <!--TODO get the actual link-->
                     <AppStore class="social-icon social-icon-blank" />
                   </a>
                 </b-col>

--- a/packages/website/src/components/DtiMainMenu.vue
+++ b/packages/website/src/components/DtiMainMenu.vue
@@ -59,32 +59,31 @@
 
     <b-collapse is-nav id="nav_collapse" v-model="navShown">
       <b-navbar-nav class="ml-auto">
-        <!-- todo look into ml-auto variants, also move routes to an actual file -->
-        <b-nav-item to="/" exact>Home</b-nav-item>
-        <b-nav-item to="/team">Team</b-nav-item>
-        <b-nav-item to="/projects">Projects</b-nav-item>
-        <b-nav-item to="/initiatives">Initiatives</b-nav-item>
-        <b-nav-item to="/courses">Courses</b-nav-item>
-        <b-nav-item to="/sponsor">Sponsor</b-nav-item>
-        <b-nav-item
+        <g-nav-item to="/" exact>Home</g-nav-item>
+        <g-nav-item to="/team/">Team</g-nav-item>
+        <g-nav-item to="/projects/">Projects</g-nav-item>
+        <g-nav-item to="/initiatives/">Initiatives</g-nav-item>
+        <g-nav-item to="/courses/">Courses</g-nav-item>
+        <g-nav-item to="/sponsor/">Sponsor</g-nav-item>
+        <g-nav-item
           v-if="
             $static.metadata.mainMenu.advertisement && $static.metadata.mainMenu.advertisement.open
           "
-          to="/apply"
+          to="/apply/"
           class="override-apply-color"
         >
           <b-button class="apply-button" variant="primary">Apply Now!</b-button>
-        </b-nav-item>
-        <b-nav-item v-else to="/apply">Apply</b-nav-item>
-        <b-nav-item
+        </g-nav-item>
+        <g-nav-item v-else to="/apply/">Apply</g-nav-item>
+        <g-nav-item
           v-if="$static.metadata.mainMenu.giving && $static.metadata.mainMenu.giving.show"
-          to="/give"
+          to="/give/"
           class="override-apply-color"
         >
           <b-button class="apply-button" variant="primary"
             >$static.metadata.mainMenu.giving.text</b-button
           >
-        </b-nav-item>
+        </g-nav-item>
       </b-navbar-nav>
     </b-collapse>
   </b-navbar>

--- a/packages/website/src/components/GNavItem.tsx
+++ b/packages/website/src/components/GNavItem.tsx
@@ -1,0 +1,16 @@
+import Vue, { RenderContext } from 'vue';
+
+export default Vue.extend({
+  functional: true,
+  render(_: unknown, cx: RenderContext<{ to: string }>) {
+    const { props, children } = cx;
+
+    return (
+      <li class="nav-item">
+        <g-link class="nav-link" to={props.to}>
+          {children}
+        </g-link>
+      </li>
+    );
+  }
+});

--- a/packages/website/src/components/MemberProfileModal.vue
+++ b/packages/website/src/components/MemberProfileModal.vue
@@ -23,8 +23,8 @@
         <b-container v-if="profile && profile.info" fluid>
           <b-row>
             <b-col>
-              <b-button class="modal-close-button close" @click="modalClose()">x</b-button>
               <!--TODO use actual icon, not text -->
+              <b-button class="modal-close-button close" @click="modalClose()">x</b-button>
             </b-col>
           </b-row>
 

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -4,6 +4,7 @@ import 'vue-meta';
 
 import DtiFooter from './components/DtiFooter.vue';
 import Give from './components/Give';
+import GNavItem from './components/GNavItem';
 import PageBackground from './components/PageBackground.vue';
 import PageHero from './components/PageHero.vue';
 import NovaHero from './components/NovaHero.vue';
@@ -34,6 +35,7 @@ export default function main(
     }
   ]);
 
+  Vue.component('GNavItem', GNavItem);
   Vue.component('PageSublist', PageSublist);
   Vue.component('DtiFooter', DtiFooter);
   Vue.component('PageBackground', PageBackground);

--- a/packages/website/src/views/Projects.vue
+++ b/packages/website/src/views/Projects.vue
@@ -25,9 +25,9 @@
           v-for="project in projectRow.members"
           :key="project.id"
         >
-          <router-link :to="{ path: project.teamId }" append>
+          <g-link :to="{ path: `/projects/${project.teamId}/` }">
             <b-img :src="project.card" class="project-card" />
-          </router-link>
+          </g-link>
         </b-col>
       </b-row>
     </page-section>


### PR DESCRIPTION
Depends on #290.

`<g-link>` is provided by Gridsome to pre-load linked pages, this speeds up page switching on the pre-rendered site.

A `<g-nav-item>` component is added to match `<b-nav-item>` from BootstrapVue.