### PR TITLE
Migrate all components to TypeScript & Update CMS for yarn workspace.

### DIFF
--- a/packages/website-components/package.json
+++ b/packages/website-components/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "website-components",
+  "version": "1.0.0",
+  "description": "Package stub for the library version of the website.",
+  "main": "dist/dti-nova.common.js",
+  "files": [
+    "dist/*"
+  ],
+  "dependencies": {},
+  "devDependencies": {},
+  "peerDependencies": {
+    "bootstrap-vue": "^2.12.0",
+    "d3": "^5.16.0",
+    "vue": "^2.6.11",
+    "vue-property-decorator": "^8.4.2"
+  }
+}

--- a/packages/website/admin/config.yml
+++ b/packages/website/admin/config.yml
@@ -1,8 +1,6 @@
 backend:
-  name: git-gateway
-  accept_roles:
-    - admin
-    - editor
+  name: github
+  open_authoring: true
   repo: cornell-dti/nova.cornelldti.org
   branch: master
 publish_mode: editorial_workflow
@@ -11,7 +9,7 @@ public_folder: /public/images/uploads
 collections:
   - name: member
     label: Member Profile
-    folder: data/members
+    folder: packages/website/data/members
     format: json
     slug: "{{netid}}"
     widget: member
@@ -81,7 +79,7 @@ collections:
       - label: Apply
         name: page-apply
         widget: object
-        file: data/pages/apply.json
+        file: packages/website/data/pages/apply.json
         fields:
           - label: hero
             name: hero
@@ -225,7 +223,7 @@ collections:
                         widget: text
       - label: Home
         name: page-home
-        file: data/pages/home.json
+        file: packages/website/data/pages/home.json
         widget: object
         fields:
           - label: Text Hero
@@ -292,7 +290,7 @@ collections:
                     widget: string
       - label: Courses
         name: page-courses
-        file: data/pages/courses.json
+        file: packages/website/data/pages/courses.json
         widget: object
         fields:
           - label: hero
@@ -341,7 +339,7 @@ collections:
                         widget: string
       - label: Sponsor
         name: page-sponsor
-        file: data/pages/sponsor.json
+        file: packages/website/data/pages/sponsor.json
         widget: object
         fields:
           - label: hero
@@ -421,7 +419,7 @@ collections:
                 widget: string
       - label: Team
         name: page-team
-        file: data/pages/team.json
+        file: packages/website/data/pages/team.json
         widget: object
         fields:
           - label: hero
@@ -498,7 +496,7 @@ collections:
     format: json
     files:
       - label: Companies
-        file: data/sets/companies.json
+        file: packages/website/data/sets/companies.json
         name: companies
         widget: object
         fields:
@@ -512,7 +510,7 @@ collections:
                 name: logo
                 widget: string
       - label: Roles
-        file: data/sets/roles.json
+        file: packages/website/data/sets/roles.json
         name: roles
         widget: object
         fields:
@@ -526,7 +524,7 @@ collections:
                 name: name
                 widget: string
       - label: Subteams
-        file: data/sets/teams.json
+        file: packages/website/data/sets/teams.json
         name: teams
         widget: list
         fields:
@@ -539,7 +537,7 @@ collections:
       - label: Diversity Stats
         name: diversity
         widget: object
-        file: data/sets/diversity.json
+        file: packages/website/data/sets/diversity.json
         fields:
           - label: femalePercentage
             name: femalePercentage
@@ -566,7 +564,7 @@ collections:
     files:
       - name: assets
         label: Assets
-        file: data/assets.json
+        file: packages/website/data/assets.json
         fields:
           - label: branding
             name: branding
@@ -587,7 +585,7 @@ collections:
                 widget: string
   - name: policies
     label: Privacy Policy
-    folder: data/privacy
+    folder: packages/website/data/privacy
     create: true
     slug: "{{id}}"
     fields:

--- a/packages/website/admin/index.js
+++ b/packages/website/admin/index.js
@@ -33,7 +33,7 @@ CMS.registerPreviewStyle('//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.mi
 // admin/1.css
 import('website-components/dist/dti-nova.css').then(() => {
   // As long as this is the only CSS import it will be "admin/1.css"
-  CMS.registerPreviewStyle('admin/1.css');
+  CMS.registerPreviewStyle('/admin/1.css');
 });
 
 // Custom Component Previews

--- a/packages/website/admin/index.js
+++ b/packages/website/admin/index.js
@@ -1,20 +1,25 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+
 import './netlifyConfig';
 
 import Vue from 'vue';
+// @ts-ignore
 import CMS from 'netlify-cms'; // -app/dist/esm
 import CMSIdentity from 'netlify-identity-widget';
 
+// @ts-ignore
 import { VueInReact } from 'vuera';
 
 // Must run `yarn build:lib` to access lib.
-import { initialize, Components } from './lib/dti-nova.common';
+// @ts-ignore
+import { initialize, Components } from 'website-components';
 
 import Profile from './preview/profile';
 import wrap from './preview/page';
 
-import('./lib/dti-nova.common.1');
-import('./lib/dti-nova.common.2');
-import('./lib/dti-nova.common.3');
+import RolesJSON from '../data/sets/roles.json';
+import TeamsJSON from '../data/sets/teams.json';
+import CompaniesJSON from '../data/sets/companies.json';
 
 initialize(Vue);
 
@@ -25,7 +30,11 @@ CMS.registerPreviewStyle('//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.mi
 
 // Load our stylesheets (only works in production builds)
 
-CMS.registerPreviewStyle('/admin/lib/dti-nova.css');
+// admin/1.css
+import('website-components/dist/dti-nova.css').then(() => {
+  // As long as this is the only CSS import it will be "admin/1.css"
+  CMS.registerPreviewStyle('admin/1.css');
+});
 
 // Custom Component Previews
 CMS.registerPreviewTemplate('member', VueInReact(Profile));
@@ -43,6 +52,23 @@ const {
 
 // Fix the lack of vue-router in Netlify CMS previews
 Vue.prototype.$route = { name: 'Preview', path: 'nowhere/' };
+
+Vue.mixin({
+  methods: {
+    getRoles() {
+      const { roles } = RolesJSON;
+      return roles;
+    },
+    getTeams() {
+      const { teams } = TeamsJSON;
+      return teams;
+    },
+    getCompanies() {
+      const { companies } = CompaniesJSON;
+      return companies;
+    }
+  }
+});
 
 Vue.component('PageSublist', PageSublist);
 Vue.component(
@@ -70,11 +96,11 @@ const TeamPage = wrap('team', Components.Team, {
   members: [],
   diversity: {
     femalePercentage: {
-      "": 0.6,
-      "business": 0.5,
-      "developer": 0.5,
-      "designer": 0.5,
-      "pm": 0.5
+      '': 0.6,
+      business: 0.5,
+      developer: 0.5,
+      designer: 0.5,
+      pm: 0.5
     }
   }
 });
@@ -87,6 +113,7 @@ CMS.registerPreviewTemplate('page-courses', VueInReact(CoursesPage));
 CMS.registerPreviewTemplate('page-initiatives', VueInReact(InitiativesPage));
 CMS.registerPreviewTemplate('page-team', VueInReact(TeamPage));
 
+// @ts-ignore
 window.netlifyIdentity = CMSIdentity;
 
 CMSIdentity.on('init', () => {

--- a/packages/website/admin/netlifyConfig.js
+++ b/packages/website/admin/netlifyConfig.js
@@ -1,1 +1,3 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+// @ts-ignore
 window.CMS_MANUAL_INIT = true;

--- a/packages/website/admin/preview/page.js
+++ b/packages/website/admin/preview/page.js
@@ -1,10 +1,21 @@
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
+
 import Vue from 'vue';
 
+/**
+ * @param {any} entry
+ */
 export function entryToStrings(entry) {
   return entry.getIn(['data']).toJS();
 }
 
-export default (name, Widget, props) =>
+export default
+/**
+ * @param {string} name
+ * @param {import('vue').VueConstructor} Widget
+ * @param {any} [props]
+ */
+(name, Widget, props = {}) =>
   Vue.extend({
     name: `${name}Preview`,
     props: {

--- a/packages/website/admin/preview/profile.js
+++ b/packages/website/admin/preview/profile.js
@@ -1,18 +1,31 @@
-import Vue from 'vue';
-import { Components } from '../lib/dti-nova.common';
+/* eslint-disable @typescript-eslint/ban-ts-ignore */
 
+import Vue from 'vue';
+
+// @ts-ignore
+import { Components } from 'website-components';
+
+/**
+ * 
+ * @param {*} entry 
+ */
 export function entryToStrings(entry) {
   return entry.getIn(['data']).toJS();
 }
 
 export default Vue.extend({
   functional: true,
+  /**
+   * @param {*} h 
+   * @param {import('vue').RenderContext<{ entry: any }>} cx
+   */
   render(h, cx) {
     if (cx.props.entry) {
       const info = entryToStrings(cx.props.entry);
 
       const toggle = () => {
-        return cx.parent.$refs.modalRef.toggleModal();
+        const modal = /** @type {any} */ (cx.parent.$refs.modalRef);
+        return modal.toggleModal();
       };
 
       return h('div', [

--- a/packages/website/gridsome.server.js
+++ b/packages/website/gridsome.server.js
@@ -15,7 +15,7 @@ module.exports = function (api) {
   // for gridsome develop
   api.configureServer(app => {
     // webpack won't host these files in development mode.
-    app.use('/admin/lib', express.static(path.join(__dirname, 'admin/lib')));
+    app.use('/admin', express.static(path.resolve(__dirname, '../../dist/admin/')));
   });
 
   api.loadSource(({ addSchemaTypes, addMetadata }) => {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -5,13 +5,14 @@
   "scripts": {
     "build": "yarn build:lib && yarn build:grid",
     "build:grid": "gridsome build",
-    "build:lib": "vue-cli-service build --target lib --name dti-nova --formats commonjs --dest admin/lib src/lib.ts",
+    "build:lib": "vue-cli-service build --target lib --name dti-nova --formats commonjs --dest ../website-components/dist/ src/lib.ts",
     "serve": "gridsome develop",
     "clean-generated-files": "rm -r admin/lib",
-    "check": "tsc --noEmit",
+    "type-check": "tsc --noEmit",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
+    "website-components": "^1.0.0",
     "bootstrap-vue": "^2.14.0",
     "d3": "^5.16.0",
     "netlify-cms": "^2.10.48",

--- a/packages/website/src/App.vue
+++ b/packages/website/src/App.vue
@@ -7,11 +7,13 @@
 
 <style src="bootstrap-vue/dist/bootstrap-vue.css"></style>
 
-<script script="ts">
+<script lang="ts">
+import Vue from 'vue';
+
 import EventBus from './eventbus';
 import DtiMainMenu from './components/DtiMainMenu.vue';
 
-export default {
+export default Vue.extend({
   name: 'App',
   metaInfo: {
     title: ''
@@ -40,7 +42,7 @@ export default {
       next();
     });
   }
-};
+});
 </script>
 
 <style lang="scss">

--- a/packages/website/src/components/DtiMainMenu.vue
+++ b/packages/website/src/components/DtiMainMenu.vue
@@ -110,10 +110,13 @@ query {
 }
 </static-query>
 
-<script>
+<script lang="ts">
+import Vue from 'vue';
+import { BNavbar } from 'bootstrap-vue';
+
 import EventBus from '../eventbus';
 
-export default {
+export default Vue.extend({
   data() {
     return {
       hide: false,
@@ -123,7 +126,7 @@ export default {
     };
   },
   methods: {
-    onScroll(window) {
+    onScroll(): void {
       const yOffset =
         window.pageYOffset ||
         window.scrollY ||
@@ -135,14 +138,15 @@ export default {
       const scrollTop = yOffset - (document.documentElement.clientTop || 0);
 
       if (typeof this.$refs.dtinavbar !== 'undefined') {
-        const height = this.$refs.dtinavbar.$el.offsetHeight;
+        const navbar = this.$refs.dtinavbar as BNavbar;
+        const height = (navbar.$el as HTMLElement).offsetHeight;
         this.transparent = scrollTop <= height;
       } else {
         this.transparent = false;
       }
     }
   },
-  destroy() {
+  destroyed() {
     window.removeEventListener('scroll', this.onScroll);
   },
   mounted() {
@@ -161,7 +165,7 @@ export default {
       this.hide = false;
     });
   }
-};
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/website/src/components/HeadshotCard.vue
+++ b/packages/website/src/components/HeadshotCard.vue
@@ -29,10 +29,12 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
+import Vue from 'vue';
+
 import MissingImage from '../assets/other/missing.svg';
 
-export default {
+export default Vue.extend({
   components: {
     MissingImage
   },
@@ -59,7 +61,7 @@ export default {
       default: 'backed'
     }
   }
-};
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/website/src/components/PageBackground.vue
+++ b/packages/website/src/components/PageBackground.vue
@@ -5,7 +5,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 export default {};
 </script>
 

--- a/packages/website/src/components/PageHero.vue
+++ b/packages/website/src/components/PageHero.vue
@@ -10,8 +10,10 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
   props: {
     bg: {
       type: String,
@@ -31,7 +33,7 @@ export default {
       return `background: ${this.bg};`;
     }
   }
-};
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/website/src/components/PageSublist.vue
+++ b/packages/website/src/components/PageSublist.vue
@@ -4,15 +4,17 @@
   </div>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
   props: {
     borderPadding: {
       type: Boolean,
       default: false
     }
   }
-};
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/website/src/components/Quicklink.vue
+++ b/packages/website/src/components/Quicklink.vue
@@ -19,8 +19,10 @@
   </b-row>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
   props: {
     image: {
       type: String
@@ -35,7 +37,7 @@ export default {
       type: String
     }
   }
-};
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/website/src/components/StoreBadge.vue
+++ b/packages/website/src/components/StoreBadge.vue
@@ -7,12 +7,14 @@
   </a>
 </template>
 
-<script>
+<script lang="ts">
+import Vue from 'vue';
+
 import AppStoreBadge from '../assets/stores/app-store.svg';
 import GooglePlayBadge from '../assets/stores/google-play.svg';
 
-export default {
+export default Vue.extend({
   components: { AppStoreBadge, GooglePlayBadge },
   props: { store: String, url: String }
-};
+});
 </script>

--- a/packages/website/src/components/TextHero.vue
+++ b/packages/website/src/components/TextHero.vue
@@ -14,8 +14,10 @@
   </page-section>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
   props: {
     header: {
       type: String
@@ -24,7 +26,7 @@ export default {
       type: String
     }
   }
-};
+});
 </script>
 
 <style lang="scss" scoped>

--- a/packages/website/src/components/TextPageHero.vue
+++ b/packages/website/src/components/TextPageHero.vue
@@ -24,14 +24,16 @@
 }
 </style>
 
-<script>
+<script lang="ts">
+import Vue from 'vue';
+
 import PageHero from './PageHero.vue';
 
-export default {
+export default Vue.extend({
   extends: PageHero,
   props: {
     header: { type: String, default: '' },
     subheader: { type: String, default: '' }
   }
-};
+});
 </script>

--- a/packages/website/src/components/TimelineSection.vue
+++ b/packages/website/src/components/TimelineSection.vue
@@ -60,8 +60,10 @@
 }
 </style>
 
-<script>
-export default {
+<script lang="ts">
+import Vue from 'vue';
+
+export default Vue.extend({
   props: {
     header: {
       type: String
@@ -70,5 +72,5 @@ export default {
       type: String
     }
   }
-};
+});
 </script>

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -48,9 +48,6 @@ export default function main(
 
   Vue.mixin({
     methods: {
-      getHeadshot(netid: string) {
-        return `/static/members/${netid}.jpg`;
-      },
       getRoles() {
         const { roles } = RolesJSON;
         return roles;
@@ -65,5 +62,6 @@ export default function main(
       }
     }
   });
+
   initializeVue(Vue);
 }

--- a/packages/website/src/pages/Privacy.vue
+++ b/packages/website/src/pages/Privacy.vue
@@ -47,7 +47,6 @@ interface PolicyPage {
   }
 })
 class Privacy extends Page<PrivacyContent>(json) {
-
   get policies(): PrivacyPolicy[] {
     return (this.$static as PolicyPage).policies.edges.map(e => e.node);
   }

--- a/packages/website/src/pages/Projects.vue
+++ b/packages/website/src/pages/Projects.vue
@@ -47,7 +47,6 @@ interface ProjectsPage {
   }
 })
 class Projects extends Page<ProjectsContent>(json) {
-
   get members(): Member[] {
     const members = (this.$static as ProjectsPage).members.edges.map(e => e.node);
     return members;

--- a/packages/website/src/shared.ts
+++ b/packages/website/src/shared.ts
@@ -7,6 +7,16 @@ import { VueConstructor, CreateElement, RenderContext } from 'vue';
 export { Project, Member, Team, Company, Role } from './types';
 
 export function initializeVue(Vue: VueConstructor) {
+  Vue.use(BootstrapVue);
+
+  Vue.mixin({
+    methods: {
+      getHeadshot(netid: string) {
+        return `/static/members/${netid}.jpg`;
+      }
+    }
+  });
+
   Vue.component('StringsDomain', {
     name: 'StringsDomain',
     functional: true,
@@ -29,8 +39,4 @@ export function initializeVue(Vue: VueConstructor) {
       return h();
     }
   });
-
-  Vue.use(BootstrapVue);
-
-  return [];
 }

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -1,5 +1,7 @@
 {
   "compilerOptions": {
+    "checkJs": true,
+    "allowJs": true,
     "target": "esnext",
     "module": "esnext",
     "strict": true,
@@ -19,7 +21,8 @@
       "dom",
       "dom.iterable",
       "scripthost"
-    ]
+    ],
+    "outDir": "dist"
   },
   "include": [
     "admin/**/*.js",


### PR DESCRIPTION
* Enable `allowJS` and `checkJS`.
* Migrate remaining JavaScript components to TypeScript to allow checkJS.
* Add admin/ to type-checked files.
* Add `website-components` package stub instead of building the website component library into `admin/lib`
* Update CMS for new workspace file paths.
* Switch CMS to GitHub backend - the site will not rely on our GitHub repo permissions.
* @ts-ignore any imports in `admin/` which do not have type definitions, the benefits of keeping `admin/` type-checked are more important (`admin/` would have thrown an error given the file path changes if it had been checked)