### PR TITLE
Fix member previews and templates, split member render out of modal.

### DIFF
--- a/packages/website/admin/config.yml
+++ b/packages/website/admin/config.yml
@@ -1,7 +1,5 @@
 backend:
-  name: github
-  open_authoring: true
-  repo: cornell-dti/nova.cornelldti.org
+  name: git-gateway
   branch: master
 publish_mode: editorial_workflow
 media_folder: static/images/uploads
@@ -35,9 +33,11 @@ collections:
         required: false
       - label: Linkedin
         name: linkedin
+        required: false
         widget: string
       - label: Github
         name: github
+        required: false
         widget: string
       - label: Hometown
         name: hometown

--- a/packages/website/admin/index.js
+++ b/packages/website/admin/index.js
@@ -31,10 +31,10 @@ CMS.registerPreviewStyle('//unpkg.com/bootstrap-vue@latest/dist/bootstrap-vue.mi
 // Load our stylesheets (only works in production builds)
 
 // admin/1.css
-import('website-components/dist/dti-nova.css').then(() => {
-  // As long as this is the only CSS import it will be "admin/1.css"
-  CMS.registerPreviewStyle('/admin/1.css');
-});
+import('website-components/dist/dti-nova.css');
+
+// As long as this is the only CSS import it will be "admin/1.css"
+CMS.registerPreviewStyle('/admin/1.css');
 
 // Custom Component Previews
 CMS.registerPreviewTemplate('member', VueInReact(Profile));

--- a/packages/website/admin/preview/profile.js
+++ b/packages/website/admin/preview/profile.js
@@ -7,7 +7,7 @@ import { Components } from 'website-components';
 
 /**
  * 
- * @param {*} entry 
+ * @param {*} entry
  */
 export function entryToStrings(entry) {
   return entry.getIn(['data']).toJS();
@@ -16,46 +16,21 @@ export function entryToStrings(entry) {
 export default Vue.extend({
   functional: true,
   /**
-   * @param {*} h 
+   * @param {*} h
    * @param {import('vue').RenderContext<{ entry: any }>} cx
    */
   render(h, cx) {
     if (cx.props.entry) {
       const info = entryToStrings(cx.props.entry);
 
-      const toggle = () => {
-        const modal = /** @type {any} */ (cx.parent.$refs.modalRef);
-        return modal.toggleModal();
-      };
-
-      return h('div', [
-        h(
-          'button',
-          {
-            domProps: {
-              innerHTML: 'Show Modal'
-            },
-            on: {
-              click: () => {
-                toggle();
-              }
-            }
-          },
-          [
-            h(Components.MemberProfileModal, {
-              ref: 'modalRef',
-              props: {
-                isStatic: true,
-                display: true,
-                profile: {
-                  id: info.netid || undefined,
-                  info
-                }
-              }
-            })
-          ]
-        )
-      ]);
+      return h(Components.MemberProfile, {
+        props: {
+          profile: {
+            id: info.netid || undefined,
+            info
+          }
+        }
+      });
     }
 
     return h('div');

--- a/packages/website/gridsome.server.js
+++ b/packages/website/gridsome.server.js
@@ -24,7 +24,6 @@ module.exports = function (api) {
     addSchemaTypes(`
       type Member implements Node {
         netid: String
-        image: String
         firstName: String
         lastName: String
         name: String

--- a/packages/website/src/components/MemberProfile.vue
+++ b/packages/website/src/components/MemberProfile.vue
@@ -1,0 +1,344 @@
+<template>
+  <b-row>
+    <b-col col>
+      <b-img
+        v-if="internalDisplay"
+        center
+        rounded="circle"
+        class="profile-image"
+        :src="getHeadshot(profile.info.netid)"
+        @error="imageError"
+      ></b-img>
+      <div v-else center rounded="circle" class="profile-image rounded-circle mx-auto">
+        <MissingImage class="profile-image-missing" />
+      </div>
+      <b-row class="profile-main">
+        <b-col class="my-auto">
+          <div class="profile-name-header">
+            <div v-if="typeof profile.info.name === 'undefined'">
+              >{{ profile.info.firstName }} {{ profile.info.lastName }}
+            </div>
+            <div v-else>{{ profile.info.name }}</div>
+          </div>
+          <div class="profile-role text-dark">
+            {{ profile.info.roleDescription || 'No Profile Available' }}
+          </div>
+        </b-col>
+      </b-row>
+      <b-row v-if="profile.info.graduation" class="profile-facts" id="profile-spacing">
+        <b-col cols="5" class="profile-label">Graduating</b-col>
+        <b-col cols="7" class="profile-details">{{ profile.info.graduation }}</b-col>
+      </b-row>
+      <b-row v-if="profile.info.major" class="profile-facts">
+        <b-col cols="5" class="profile-label">Major</b-col>
+        <b-col cols="7" class="profile-details">{{ profile.info.major }}</b-col>
+      </b-row>
+      <template v-if="profile.info.minor && profile.info.minor">
+        <b-row class="profile-facts">
+          <b-col cols="5" class="profile-label">Minor</b-col>
+          <b-col cols="7" class="profile-details">{{ profile.info.minor }}</b-col>
+        </b-row>
+      </template>
+      <b-row v-if="profile.info.hometown" class="profile-facts">
+        <b-col cols="5" class="profile-label">Hometown</b-col>
+        <b-col cols="7" class="profile-details">{{ profile.info.hometown }}</b-col>
+      </b-row>
+      <div v-if="profile.info.website">
+        <b-row class="profile-facts">
+          <b-col cols="5" class="profile-label">Website</b-col>
+          <b-col cols="7" class="profile-details">
+            <a class="personalwebsite" :href="profile.info.website">{{ profile.info.website }}</a>
+          </b-col>
+        </b-row>
+      </div>
+      <div v-if="profile.info.github || profile.info.linkedin">
+        <b-row class="social-media">
+          <b-col v-if="profile.info.github" class="social-link" cols="auto">
+            <a :href="profile.info.github">
+              <Github class="social-icon" />
+            </a>
+          </b-col>
+          <b-col v-if="profile.info.linkedin" class="social-link" cols="auto">
+            <a :href="profile.info.linkedin">
+              <LinkedIn class="social-icon" />
+            </a>
+          </b-col>
+        </b-row>
+      </div>
+    </b-col>
+    <template v-if="profile.info.about || profile.info.subteam">
+      <b-col lg="1" cols="0">
+        <div class="divider" />
+      </b-col>
+      <b-col lg="6" cols="0" class="left-shift">
+        <div v-if="profile.info.about" class="about-section">
+          <b-row class="about-title">
+            <b-col class="member-modal-header left-space">About Me</b-col>
+          </b-row>
+          <b-row>
+            <b-col class="about-p left-space">{{ profile.info.about }}</b-col>
+          </b-row>
+        </div>
+        <b-row
+          v-if="
+            profile.info.subteam ||
+              (profile.info.otherSubteams && profile.info.otherSubteams.length > 0)
+          "
+        >
+          <b-col>
+            <div id="teamwork" class="member-modal-header left-space">Team Work</div>
+            <ul class="team-info-list left-space">
+              <template v-for="team of teams">
+                <li class="team-info-item my-auto" :key="team.id">{{ team.name }}</li>
+              </template>
+            </ul>
+          </b-col>
+        </b-row>
+      </b-col>
+    </template>
+  </b-row>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { Component, Watch } from 'vue-property-decorator';
+
+import { ObjectProp } from '../util/common';
+
+import Github from '../assets/social/github.svg';
+import LinkedIn from '../assets/social/linkedin.svg';
+import MissingImage from '../assets/other/missing.svg';
+import { Member } from '../shared';
+import { Team } from '../types';
+
+@Component({
+  components: {
+    Github,
+    LinkedIn,
+    MissingImage
+  }
+})
+export default class MemberProfileModal extends Vue {
+  @ObjectProp()
+  profile!: { info: Member };
+
+  internalDisplay = true;
+
+  get subteams(): string[] {
+    const { subteam } = this.profile.info;
+    const subteams = subteam ? [subteam] : [];
+    const other = this.profile.info.otherSubteams;
+
+    if (Array.isArray(other)) {
+      subteams.push(...other);
+    } else if (typeof other === 'string') {
+      subteams.push(other);
+    }
+
+    return subteams;
+  }
+
+  @Watch('profile')
+  onProfileChanged() {
+    this.internalDisplay = true;
+  }
+
+  imageError() {
+    this.internalDisplay = false;
+  }
+
+  get teams(): Team[] {
+    return this.subteams
+      .map(team => {
+        return this.getTeams().find(teamData => teamData.id === team);
+      })
+      .filter((d): d is Team => d != null);
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.member-modal-header {
+  font-size: 1.25rem;
+  font-weight: bold;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.3px;
+  color: #000000;
+}
+
+.left-space {
+  margin-left: 0.625rem;
+}
+
+.about-p {
+  margin-top: 0.625rem;
+  font-size: 0.875rem;
+  font-family: Raleway;
+  margin-right: 0.625rem;
+}
+
+.left-shift {
+  margin-left: -2.5%;
+}
+
+.profile-text {
+  text-align: center;
+}
+
+.profile-main {
+  margin-bottom: 5%;
+}
+
+.profile-name-header {
+  text-align: center;
+  margin-top: 0.625rem;
+  font-size: 1.5rem;
+  font-weight: 600;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.3px;
+  color: #000000;
+}
+
+.profile-role {
+  text-align: center;
+  opacity: 0.8;
+  font-family: Raleway;
+  font-size: 1rem;
+  font-weight: 600;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: normal;
+  letter-spacing: 0.3px;
+  color: #000000;
+}
+
+#profile-spacing {
+  margin-top: 5%;
+}
+
+.profile-facts {
+  margin-top: 0.3125rem;
+  font-family: Raleway;
+  font-size: 0.875rem;
+}
+
+.profile-label {
+  font-weight: 600;
+}
+
+.profile-details {
+  margin-left: -1.875rem;
+  font-weight: 400;
+}
+
+.personalwebsite {
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.divider {
+  background-color: #4a4a4a;
+  opacity: 0.5;
+  width: 0.125rem;
+  height: 100%;
+}
+
+.social-icon {
+  width: 2rem;
+  height: 2rem;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 5%;
+}
+
+.profile-image {
+  height: 9.375rem;
+  width: 9.375rem;
+  border: 0.05rem #979797 solid;
+  object-fit: cover;
+}
+
+.social-media {
+  padding-top: 1rem;
+  justify-content: center;
+
+  .social-link {
+    margin: 0.5rem;
+  }
+}
+
+.profile-image-missing {
+  width: 100%;
+  height: auto;
+  border-radius: 50%;
+}
+
+.about-section {
+  margin-bottom: 1.25rem;
+}
+
+@media (min-width: 992) {
+  .modal-dialog {
+    max-width: 960px;
+    margin: 10%;
+  }
+  .about-title {
+    overflow-y: auto;
+    max-height: inherit;
+  }
+}
+
+@media (max-width: 991px) {
+  .social-icon {
+    margin-top: 10%;
+  }
+
+  .divider {
+    background-color: white;
+  }
+
+  .about-title {
+    margin-top: 10%;
+  }
+
+  .modal-dialog {
+    max-width: 800px;
+    margin: 10%;
+  }
+
+  .left-space {
+    margin-left: 0rem;
+  }
+
+  .mobile-modal-scroll {
+    overflow-y: auto;
+    max-height: 70vh;
+  }
+
+  .link-list {
+    padding-left: 50px;
+  }
+}
+
+/*put position:fixed on the main page behind the modal */
+.team-logo {
+  padding-right: 2rem;
+}
+
+.team-info-list {
+  padding-top: 0.2rem;
+  list-style-type: none;
+  margin-bottom: 0;
+  padding-left: 0;
+}
+
+.team-info-item {
+  margin-bottom: 0;
+}
+</style>

--- a/packages/website/src/components/MemberProfileModal.vue
+++ b/packages/website/src/components/MemberProfileModal.vue
@@ -28,106 +28,7 @@
             </b-col>
           </b-row>
 
-          <b-row class="modal-scroll">
-            <b-col col>
-              <b-img
-                v-if="internalDisplay"
-                center
-                rounded="circle"
-                class="profile-image"
-                :src="getHeadshot(profile.info.netid)"
-                @error="imageError"
-              ></b-img>
-              <div v-else center rounded="circle" class="profile-image rounded-circle mx-auto">
-                <MissingImage class="profile-image-missing" />
-              </div>
-              <b-row class="profile-main">
-                <b-col class="my-auto">
-                  <div class="profile-name-header">
-                    <div v-if="typeof profile.info.name === 'undefined'">
-                      >{{ profile.info.firstName }} {{ profile.info.lastName }}
-                    </div>
-                    <div v-else>{{ profile.info.name }}</div>
-                  </div>
-                  <div class="profile-role text-dark">
-                    {{ profile.info.roleDescription || 'No Profile Available' }}
-                  </div>
-                </b-col>
-              </b-row>
-              <b-row v-if="profile.info.graduation" class="profile-facts" id="profile-spacing">
-                <b-col cols="5" class="profile-label">Graduating</b-col>
-                <b-col cols="7" class="profile-details">{{ profile.info.graduation }}</b-col>
-              </b-row>
-              <b-row v-if="profile.info.major" class="profile-facts">
-                <b-col cols="5" class="profile-label">Major</b-col>
-                <b-col cols="7" class="profile-details">{{ profile.info.major }}</b-col>
-              </b-row>
-              <template v-if="profile.info.minor && profile.info.minor">
-                <b-row class="profile-facts">
-                  <b-col cols="5" class="profile-label">Minor</b-col>
-                  <b-col cols="7" class="profile-details">{{ profile.info.minor }}</b-col>
-                </b-row>
-              </template>
-              <b-row v-if="profile.info.hometown" class="profile-facts">
-                <b-col cols="5" class="profile-label">Hometown</b-col>
-                <b-col cols="7" class="profile-details">{{ profile.info.hometown }}</b-col>
-              </b-row>
-              <div v-if="profile.info.website">
-                <b-row class="profile-facts">
-                  <b-col cols="5" class="profile-label">Website</b-col>
-                  <b-col cols="7" class="profile-details">
-                    <a class="personalwebsite" :href="profile.info.website">{{
-                      profile.info.website
-                    }}</a>
-                  </b-col>
-                </b-row>
-              </div>
-              <div v-if="profile.info.github || profile.info.linkedin">
-                <b-row>
-                  <b-col class="social-media">
-                    <a v-if="profile.info.github" :href="profile.info.github">
-                      <Github class="social-icon" />
-                    </a>
-                    <a v-if="profile.info.linkedin" :href="profile.info.linkedin">
-                      <LinkedIn class="social-icon" />
-                    </a>
-                  </b-col>
-                </b-row>
-              </div>
-            </b-col>
-            <template v-if="profile.info.about || profile.info.subteam">
-              <b-col lg="1" cols="0">
-                <div class="divider" />
-              </b-col>
-              <b-col lg="6" cols="0" class="left-shift">
-                <div v-if="profile.info.about" class="about-section">
-                  <b-row class="about-title">
-                    <b-col class="member-modal-header left-space">About Me</b-col>
-                  </b-row>
-                  <b-row>
-                    <b-col class="about-p left-space">{{ profile.info.about }}</b-col>
-                  </b-row>
-                </div>
-                <b-row
-                  v-if="
-                    profile.info.subteam ||
-                      (profile.info.otherSubteams && profile.info.otherSubteams.length > 0)
-                  "
-                >
-                  <b-col>
-                    <div id="teamwork" class="member-modal-header left-space">Team Work</div>
-                    <ul class="team-info-list left-space">
-                      <template v-for="team of subteams">
-                        <li class="team-info-item my-auto" :key="team">
-                          {{ getTeamName(team)[0] }}
-                        </li>
-                      </template>
-                    </ul>
-                  </b-col>
-                </b-row>
-              </b-col>
-            </template>
-          </b-row>
+          <member-profile class="modal-scroll" :profile="profile" />
         </b-container>
       </b-modal>
     </div>
@@ -136,10 +37,12 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { Component, Watch } from 'vue-property-decorator';
+import { Component } from 'vue-property-decorator';
 
 import { BModal } from 'bootstrap-vue';
 import { ObjectProp, BooleanProp } from '../util/common';
+
+import MemberProfile from './MemberProfile.vue';
 
 import Github from '../assets/social/github.svg';
 import LinkedIn from '../assets/social/linkedin.svg';
@@ -150,6 +53,7 @@ import { Member } from '../shared';
   components: {
     Github,
     LinkedIn,
+    MemberProfile,
     MissingImage
   }
 })
@@ -160,28 +64,7 @@ export default class MemberProfileModal extends Vue {
   @ObjectProp()
   profile!: { info: Member };
 
-  internalDisplay = true;
   isShowing = false;
-
-  get subteams(): string[] {
-    const subteams = [this.profile.info.subteam];
-    const other = this.profile.info.otherSubteams;
-    if (Array.isArray(other)) {
-      subteams.push(...other);
-    } else if (other) {
-      subteams.push(other);
-    }
-    return subteams;
-  }
-
-  @Watch('profile')
-  onProfileChanged() {
-    this.internalDisplay = true;
-  }
-
-  imageError() {
-    this.internalDisplay = false;
-  }
 
   modalClose() {
     const modal = (this.$refs.memberModalRef as unknown) as BModal;
@@ -196,20 +79,6 @@ export default class MemberProfileModal extends Vue {
   toggleModal() {
     const modal = (this.$refs.memberModalRef as unknown) as BModal;
     modal.toggle();
-  }
-
-  getTeamName(team: string | { id: string }) {
-    const teamNames = [] as string[];
-
-    this.getTeams().forEach(teamData => {
-      if (typeof team === 'string' && teamData.id === team) {
-        teamNames.push(teamData.name);
-      } else if (typeof team === 'object' && teamData.id === team.id) {
-        teamNames.push(teamData.name);
-      }
-    });
-
-    return teamNames;
   }
 }
 </script>
@@ -230,115 +99,30 @@ export default class MemberProfileModal extends Vue {
 $radius: 25px;
 
 #memberModal {
-  .member-modal-header {
-    font-size: 1.25rem;
-    font-weight: bold;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: 0.3px;
-    color: #000000;
+  .modal-scroll {
+    overflow-y: auto;
+    max-height: 70vh;
   }
 
-  .left-space {
-    margin-left: 0.625rem;
-  }
-
-  .about-p {
-    margin-top: 0.625rem;
-    font-size: 0.875rem;
-    font-family: Raleway;
-    margin-right: 0.625rem;
-  }
-
-  .left-shift {
-    margin-left: -2.5%;
-  }
-
-  .profile-text {
-    text-align: center;
-  }
-
-  .profile-main {
-    margin-bottom: 5%;
-  }
-
-  .profile-name-header {
-    text-align: center;
-    margin-top: 0.625rem;
-    font-size: 1.5rem;
-    font-weight: 600;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: 0.3px;
-    color: #000000;
-  }
-
-  .profile-role {
-    text-align: center;
-    opacity: 0.8;
-    font-family: Raleway;
-    font-size: 1rem;
-    font-weight: 600;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: 0.3px;
-    color: #000000;
-  }
-
-  #profile-spacing {
-    margin-top: 5%;
-  }
-
-  .profile-facts {
-    margin-top: 0.3125rem;
-    font-family: Raleway;
-    font-size: 0.875rem;
-  }
-
-  .profile-label {
-    font-weight: 600;
-  }
-
-  .profile-details {
-    margin-left: -1.875rem;
-    font-weight: 400;
-  }
-
-  .personalwebsite {
-    display: block;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
-
-  .social-media {
-    display: inline;
-    margin-left: auto;
-    margin-right: auto;
-    text-align: center;
-  }
-
-  .divider {
-    background-color: #4a4a4a;
-    opacity: 0.5;
-    width: 0.125rem;
-    height: 100%;
-  }
-
-  .social-icon {
-    width: 2rem;
-    height: 2rem;
-    margin-left: auto;
-    margin-right: auto;
-    margin-top: 5%;
+  @media (max-width: 991px) {
+    .modal-scroll {
+      overflow-y: auto;
+      max-height: 70vh;
+    }
   }
 
   .modal-content {
     border: none !important;
     border-radius: ($radius + 5) !important;
+  }
+
+  .modal-body {
+    border-top-left-radius: $radius;
+    border-top-right-radius: $radius;
+    border-bottom-right-radius: $radius;
+    border-bottom-left-radius: $radius;
+    padding: 2em;
+    overflow: hidden;
   }
 
   .modal-close-button {
@@ -353,101 +137,6 @@ $radius: 25px;
   .modal-header,
   .modal-footer {
     display: none;
-  }
-
-  .modal-scroll {
-    overflow-y: auto;
-    max-height: 70vh;
-  }
-
-  .modal-body {
-    border-top-left-radius: $radius;
-    border-top-right-radius: $radius;
-    border-bottom-right-radius: $radius;
-    border-bottom-left-radius: $radius;
-    padding: 2em;
-    overflow: hidden;
-
-    .profile-image {
-      height: 9.375rem;
-      width: 9.375rem;
-      border: 0.05rem #979797 solid;
-      object-fit: cover;
-    }
-
-    .profile-image-missing {
-      width: 100%;
-      height: auto;
-      border-radius: 50%;
-    }
-
-    .about-section {
-      margin-bottom: 1.25rem;
-    }
-
-    @media (min-width: 992) {
-      .modal-dialog {
-        max-width: 960px;
-        margin: 10%;
-      }
-      .about-title {
-        overflow-y: auto;
-        max-height: inherit;
-      }
-    }
-
-    @media (max-width: 991px) {
-      .social-icon {
-        margin-top: 10%;
-      }
-
-      .divider {
-        background-color: white;
-      }
-
-      .about-title {
-        margin-top: 10%;
-      }
-
-      .modal-dialog {
-        max-width: 800px;
-        margin: 10%;
-      }
-
-      .modal-scroll {
-        overflow-y: auto;
-        max-height: 70vh;
-      }
-
-      .left-space {
-        margin-left: 0rem;
-      }
-
-      .mobile-modal-scroll {
-        overflow-y: auto;
-        max-height: 70vh;
-      }
-
-      .link-list {
-        padding-left: 50px;
-      }
-    }
-
-    /*put position:fixed on the main page behind the modal */
-    .team-logo {
-      padding-right: 2rem;
-    }
-
-    .team-info-list {
-      padding-top: 0.2rem;
-      list-style-type: none;
-      margin-bottom: 0;
-      padding-left: 0;
-    }
-
-    .team-info-item {
-      margin-bottom: 0;
-    }
   }
 }
 </style>

--- a/packages/website/src/components/NavbarPadding.vue
+++ b/packages/website/src/components/NavbarPadding.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="navbar-padding" />
+</template>
+
+<style lang="scss" scoped>
+.navbar-padding {
+  padding-top: 10vh !important;
+}
+</style>

--- a/packages/website/src/components/PageHero.vue
+++ b/packages/website/src/components/PageHero.vue
@@ -3,7 +3,7 @@
     :style="bg_()"
     :class="['page-header', 'page-hero', this.greyscale ? 'page-hero-greyscale' : '']"
   >
-    <div class="navbar-padding" />
+    <navbar-padding />
     <slot>
       <slot name="inner-content" />
     </slot>
@@ -37,10 +37,6 @@ export default Vue.extend({
 </script>
 
 <style lang="scss" scoped>
-.navbar-padding {
-  padding-top: 10vh !important;
-}
-
 .page-header {
   min-height: 10vh;
   background-size: cover !important;

--- a/packages/website/src/lib.ts
+++ b/packages/website/src/lib.ts
@@ -20,7 +20,7 @@ import PageSublist from './components/PageSublist.vue';
 import TextPageHero from './components/TextPageHero.vue';
 import TextHero from './components/TextHero.vue';
 import PageSection from './components/PageSection.vue';
-import MemberProfileModal from './components/MemberProfileModal.vue';
+import MemberProfile from './components/MemberProfile.vue';
 import DTIProject from './templates/DTIProject.vue';
 
 import { initializeVue } from './shared';
@@ -34,7 +34,7 @@ const Components = {
   Sponsor,
   Team: TeamView,
   DtiFooter,
-  MemberProfileModal,
+  MemberProfile,
   PageBackground,
   PageHero,
   NovaHero,

--- a/packages/website/src/main.ts
+++ b/packages/website/src/main.ts
@@ -7,6 +7,7 @@ import Give from './components/Give';
 import GNavItem from './components/GNavItem';
 import PageBackground from './components/PageBackground.vue';
 import PageHero from './components/PageHero.vue';
+import NavbarPadding from './components/NavbarPadding.vue';
 import NovaHero from './components/NovaHero.vue';
 import PageSublist from './components/PageSublist.vue';
 import TextPageHero from './components/TextPageHero.vue';
@@ -41,6 +42,7 @@ export default function main(
   Vue.component('PageBackground', PageBackground);
   Vue.component('PageSection', PageSection);
   Vue.component('PageHero', PageHero);
+  Vue.component('NavbarPadding', NavbarPadding);
   Vue.component('NovaHero', NovaHero);
   Vue.component('TextPageHero', TextPageHero);
   Vue.component('TextHero', TextHero);

--- a/packages/website/src/pages/Team.vue
+++ b/packages/website/src/pages/Team.vue
@@ -7,8 +7,7 @@ query Members {
   members: allMember {
     edges {
       node {
-        netid
-        image       
+        netid      
         firstName
         lastName
         name

--- a/packages/website/src/templates/DTIProject.vue
+++ b/packages/website/src/templates/DTIProject.vue
@@ -69,8 +69,7 @@ query DTIProjects ($path: String!, $teamId: String!) {
   currentMembers: allMember(filter: { subteam: { in: [$teamId] }}) {
     edges {
       node {
-        netid
-        image       
+        netid    
         firstName
         lastName
         name
@@ -92,8 +91,7 @@ query DTIProjects ($path: String!, $teamId: String!) {
   pastMembers: allMember(filter: { otherSubteams: { contains: [$teamId] }}) {
     edges {
       node {
-        netid
-        image       
+        netid      
         firstName
         lastName
         name

--- a/packages/website/src/templates/Member.vue
+++ b/packages/website/src/templates/Member.vue
@@ -16,8 +16,7 @@
 <page-query>
 query DTIMember($path: String!) {
   member: member(path: $path) {
-    netid
-    image       
+    netid      
     firstName
     lastName
     name

--- a/packages/website/src/templates/Member.vue
+++ b/packages/website/src/templates/Member.vue
@@ -1,9 +1,68 @@
 <template>
-  <div />
+  <page-background>
+    <navbar-padding />
+    <b-container class="member-padding">
+      <member-profile :profile="profile" />
+    </b-container>
+  </page-background>
 </template>
+
+<style lang="scss" scoped>
+.member-padding {
+  margin: 2rem;
+}
+</style>
+
+<page-query>
+query DTIMember($path: String!) {
+  member: member(path: $path) {
+    netid
+    image       
+    firstName
+    lastName
+    name
+    graduation
+    major
+    linkedin
+    github
+    hometown
+    about
+    subteam
+    otherSubteams
+    website
+    roleId
+    roleDescription
+  }
+}
+</page-query>
 
 <script lang="ts">
 import Vue from 'vue';
+import { Component } from 'vue-property-decorator';
 
-export default Vue.extend({});
+import MemberProfile from '../components/MemberProfile.vue';
+
+import EventBus from '../eventbus';
+import { Member } from '../types';
+
+interface MemberPage {
+  member: Member;
+}
+
+@Component({
+  components: {
+    MemberProfile
+  }
+})
+export default class MemberTemplate extends Vue {
+  get profile() {
+    return {
+      info: (this.$page as MemberPage).member
+    };
+  }
+
+  mounted() {
+    EventBus.$emit('set-navbar-light', { source: this });
+  }
+}
 </script>

--- a/packages/website/src/types.ts
+++ b/packages/website/src/types.ts
@@ -1,6 +1,5 @@
 export interface Member {
   netid: string;
-  image: string;
   name: string;
   firstName: string;
   lastName: string;

--- a/packages/website/src/types.ts
+++ b/packages/website/src/types.ts
@@ -7,7 +7,7 @@ export interface Member {
   isLead?: boolean;
   roleId: string;
   otherSubteams?: string[] | string | undefined;
-  subteam: string;
+  subteam?: string;
   graduation: string;
   major: string;
   doubleMajor: string;


### PR DESCRIPTION
* Make member profile rendering a separate component so we can display it in templates and previews.
* Avoid assuming a member always has a subteam when otherSubteams is defined (business breaks this pattern)
* Unconditionally import the admin panel CSS as on some CMS pages the initial condition will fail without impact.
* Make navbar padding a reusable component.
* Update member type definition to make subteam optional.