### PR TITLE
Eliminate strings-domain component usages

### DIFF
--- a/packages/website/data/pages/courses.json
+++ b/packages/website/data/pages/courses.json
@@ -19,8 +19,7 @@
       "buttons": {
         "apply": {
           "title": "Apply",
-          "link": "https://bit.ly/web-dev-sp21",
-          "icon": "apply"
+          "link": "https://bit.ly/web-dev-sp21"
         }
       },
       "subDescription1": [

--- a/packages/website/src/components/ProjectGoTo.vue
+++ b/packages/website/src/components/ProjectGoTo.vue
@@ -1,56 +1,51 @@
 <template>
   <b-row>
     <b-col cols="auto">
-      <strings-domain
-        v-if="project"
-        #key="{website, website_title: websiteTitle, playstore, appstore, ios_github, android_github, github }"
-        :value="project"
-      >
-        <b-row>
-          <b-col cols="auto" v-if="website">
-            <b-button :href="website">
-              {{ `Go to ${websiteTitle || website}` }}
-            </b-button>
-          </b-col>
-
-          <b-col cols="auto" v-if="playstore">
-            <store-badge store="playstore" :url="playstore" />
-          </b-col>
-          <b-col cols="auto" v-if="appstore">
-            <store-badge store="appstore" :url="appstore" />
-          </b-col>
-          <b-col
-            class="connect-icon-container"
-            cols="auto"
-            v-if="ios_github && !appstore && !playstore && !website"
-          >
-            <b-button class="align-content-center" :href="ios_github">
-              <Github class="connect-icon connect-icon-blank" />
-              <span class="connect-text">iOS</span>
-            </b-button>
-          </b-col>
-          <b-col
-            class="connect-icon-container"
-            cols="auto"
-            v-if="android_github && !appstore && !playstore && !website"
-          >
-            <b-button class="align-content-center" :href="android_github">
-              <Github class="connect-icon connect-icon-blank" />
-              <span class="connect-text">Android</span>
-            </b-button>
-          </b-col>
-          <b-col
-            class="connect-icon-container"
-            cols="auto"
-            v-if="github && !appstore && !playstore && !website"
-          >
-            <b-button class="align-content-center" :href="github">
-              <Github class="connect-icon connect-icon-blank" />
-              <span class="connect-text">GitHub</span>
-            </b-button>
-          </b-col>
-        </b-row>
-      </strings-domain>
+      <b-row>
+        <b-col cols="auto" v-if="project.website">
+          <b-button :href="project.website">
+            {{ `Go to ${project['website_title'] || project.website}` }}
+          </b-button>
+        </b-col>
+        <b-col cols="auto" v-if="project.playstore">
+          <store-badge store="playstore" :url="project.playstore" />
+        </b-col>
+        <b-col cols="auto" v-if="project.appstore">
+          <store-badge store="appstore" :url="project.appstore" />
+        </b-col>
+        <b-col
+          class="connect-icon-container"
+          cols="auto"
+          v-if="project.ios_github && !project.appstore && !project.playstore && !project.website"
+        >
+          <b-button class="align-content-center" :href="project.ios_github">
+            <Github class="connect-icon connect-icon-blank" />
+            <span class="connect-text">iOS</span>
+          </b-button>
+        </b-col>
+        <b-col
+          class="connect-icon-container"
+          cols="auto"
+          v-if="
+            project.android_github && !project.appstore && !project.playstore && !project.website
+          "
+        >
+          <b-button class="align-content-center" :href="project.android_github">
+            <Github class="connect-icon connect-icon-blank" />
+            <span class="connect-text">Android</span>
+          </b-button>
+        </b-col>
+        <b-col
+          class="connect-icon-container"
+          cols="auto"
+          v-if="project.github && !project.appstore && !project.playstore && !project.website"
+        >
+          <b-button class="align-content-center" :href="project.github">
+            <Github class="connect-icon connect-icon-blank" />
+            <span class="connect-text">GitHub</span>
+          </b-button>
+        </b-col>
+      </b-row>
     </b-col>
   </b-row>
 </template>

--- a/packages/website/src/components/ProjectLearnMore.vue
+++ b/packages/website/src/components/ProjectLearnMore.vue
@@ -1,70 +1,49 @@
 <template>
-  <strings-domain
-    v-if="project"
-    #key="{
-      website,
-      website_title,
-      playstore,
-      medium,
-      appstore,
-      ios_github,
-      android_github,
-      github
-    }"
-    :value="project"
+  <page-section
+    v-if="
+      enableAll ||
+        (!website && !playstore && !appstore) ||
+        ((playstore || appstore || website) && (ios_github || android_github || github))
+    "
   >
-    <page-section
-      v-if="
-        enableAll ||
-          (!website && !playstore && !appstore && medium) ||
-          ((playstore || appstore || website) && (ios_github || android_github || github))
-      "
-    >
-      <div class="project-header">Learn More</div>
-      <b-row>
-        <b-col cols="auto">
-          <b-row>
-            <b-col
-              class="connect-icon-container"
-              cols="auto"
-              v-if="(enableAll || website || playstore || appstore) && ios_github"
-            >
-              <b-button class="align-content-center" :href="ios_github">
-                <Github class="connect-icon connect-icon-blank" />
-                <span class="connect-text">iOS</span>
-              </b-button>
-            </b-col>
-            <b-col
-              class="connect-icon-container"
-              cols="auto"
-              v-if="(enableAll || website || playstore || appstore) && android_github"
-            >
-              <b-button class="align-content-center" :href="android_github">
-                <Github class="connect-icon connect-icon-blank" />
-                <span class="connect-text">Android</span>
-              </b-button>
-            </b-col>
-            <b-col
-              class="connect-icon-container"
-              cols="auto"
-              v-if="(enableAll || website || playstore || appstore) && github"
-            >
-              <b-button class="align-content-center" :href="github">
-                <Github class="connect-icon connect-icon-blank" />
-                <span class="connect-text">GitHub</span>
-              </b-button>
-            </b-col>
-            <b-col class="connect-icon-container" cols="auto" v-if="medium">
-              <b-button class="align-content-center" :href="medium">
-                <Medium class="connect-icon connect-icon-blank" />
-                <span class="connect-text">Medium</span>
-              </b-button>
-            </b-col>
-          </b-row>
-        </b-col>
-      </b-row>
-    </page-section>
-  </strings-domain>
+    <div class="project-header">Learn More</div>
+    <b-row>
+      <b-col cols="auto">
+        <b-row>
+          <b-col
+            class="connect-icon-container"
+            cols="auto"
+            v-if="(enableAll || website || playstore || appstore) && ios_github"
+          >
+            <b-button class="align-content-center" :href="ios_github">
+              <Github class="connect-icon connect-icon-blank" />
+              <span class="connect-text">iOS</span>
+            </b-button>
+          </b-col>
+          <b-col
+            class="connect-icon-container"
+            cols="auto"
+            v-if="(enableAll || website || playstore || appstore) && android_github"
+          >
+            <b-button class="align-content-center" :href="android_github">
+              <Github class="connect-icon connect-icon-blank" />
+              <span class="connect-text">Android</span>
+            </b-button>
+          </b-col>
+          <b-col
+            class="connect-icon-container"
+            cols="auto"
+            v-if="(enableAll || website || playstore || appstore) && github"
+          >
+            <b-button class="align-content-center" :href="github">
+              <Github class="connect-icon connect-icon-blank" />
+              <span class="connect-text">GitHub</span>
+            </b-button>
+          </b-col>
+        </b-row>
+      </b-col>
+    </b-row>
+  </page-section>
 </template>
 
 <script lang="ts">
@@ -74,13 +53,9 @@ import { PropValidator } from 'vue/types/options';
 import { Project } from '../shared';
 
 import Github from '../assets/social/github.svg';
-import Medium from '../assets/social/medium.svg';
 
 export default Vue.extend({
-  components: {
-    Github,
-    Medium
-  },
+  components: { Github },
   props: {
     project: {
       required: true
@@ -88,6 +63,26 @@ export default Vue.extend({
     enableAll: {
       type: Boolean,
       default: false
+    }
+  },
+  computed: {
+    website(): string | undefined {
+      return this.project.website;
+    },
+    playstore(): string | undefined {
+      return this.project.playstore;
+    },
+    appstore(): string | undefined {
+      return this.project.appstore;
+    },
+    github(): string | undefined {
+      return this.project.github;
+    },
+    ios_github(): string | undefined {
+      return this.project.ios_github;
+    },
+    android_github(): string | undefined {
+      return this.project.android_github;
     }
   }
 });

--- a/packages/website/src/components/RoleSelector.vue
+++ b/packages/website/src/components/RoleSelector.vue
@@ -293,7 +293,7 @@ export default Vue.extend({
     }
   },
   watch: {
-    roleId($event): void {
+    roleId($event: Event): void {
       this.$emit('update:change', $event);
     }
   }

--- a/packages/website/src/content.ts
+++ b/packages/website/src/content.ts
@@ -1,6 +1,8 @@
 export interface Content {
   textHero: { header: string; subheader: string };
   hero: {
+    header?: string;
+    subheader?: string;
     lazy: string;
     video: {
       mp4: string;
@@ -46,7 +48,10 @@ export interface CoursesContent extends Content {
       apply: {
         title: string;
         link: string;
-        icon: string;
+      };
+      github: {
+        title: string;
+        link: string;
       };
     };
     // 3 "sub descriptions" in a pair: first element is title and second is the desc
@@ -158,6 +163,7 @@ export interface Apply {
 
 export interface CallToActionButton {
   closed: boolean;
+  link: string;
   content: string;
 }
 
@@ -208,6 +214,8 @@ export interface PrivacyPolicy {
 
 export interface ApplyContent extends Content {
   hero: {
+    header: string;
+    subheader: string;
     closed: Closed;
     lazy: string;
     video: { mp4: string; webm: string };

--- a/packages/website/src/layouts/Default.vue
+++ b/packages/website/src/layouts/Default.vue
@@ -1,5 +1,0 @@
-<template>
-  <div>
-    <slot />
-  </div>
-</template>

--- a/packages/website/src/shared.ts
+++ b/packages/website/src/shared.ts
@@ -2,7 +2,7 @@
 
 import BootstrapVue from 'bootstrap-vue';
 
-import { VueConstructor, CreateElement, RenderContext } from 'vue';
+import { VueConstructor } from 'vue';
 
 export { Project, Member, Team, Company, Role } from './types';
 
@@ -14,29 +14,6 @@ export function initializeVue(Vue: VueConstructor): void {
       getHeadshot(netid: string) {
         return `/static/members/${netid}.jpg`;
       }
-    }
-  });
-
-  Vue.component('StringsDomain', {
-    name: 'StringsDomain',
-    functional: true,
-    props: {
-      value: {
-        required: true
-      }
-    },
-    render(h: CreateElement, cx: RenderContext<{ value: unknown }>) {
-      const { key: slot } = cx.scopedSlots;
-
-      if (slot) {
-        const node = slot(cx.props.value);
-
-        if (node) {
-          return node;
-        }
-      }
-
-      return h();
     }
   });
 }

--- a/packages/website/src/types.ts
+++ b/packages/website/src/types.ts
@@ -37,7 +37,7 @@ export interface Project {
   teamId: string;
   card: string;
   name: string;
-  features: { title: string; image: string; description: string };
+  features: readonly { title: string; image: string; description: string }[];
   header: string;
   subheader: string;
   hero: {
@@ -45,8 +45,11 @@ export interface Project {
     subheader: string;
     image?: string;
   };
+  website?: string;
+  website_title?: string;
   appstore?: string;
   playstore?: string;
+  github?: string;
   ios_github?: string;
   android_github?: string;
   heroStartingColor: string;

--- a/packages/website/src/views/Apply.vue
+++ b/packages/website/src/views/Apply.vue
@@ -1,211 +1,164 @@
 <template class="applyPage">
   <page-background>
-    <strings-domain :value="content.joinInformation.applicationsOpen" #key="isOpen">
-      <strings-domain :value="[content.hero, content.hero.closed]" #key="[hero, closed]">
-        <nova-hero
-          v-if="hero && isOpen"
-          :header="hero.header"
-          :subheader="hero.subheader"
-          :video="hero.video"
-          :lazy="hero.lazy"
-          :image="hero.image"
-          page="apply"
-        />
-        <nova-hero v-else :video="hero.video" :lazy="hero.lazy" :image="hero.image" page="apply" />
-        <page-section v-if="!isOpen">
-          <b-container class="email-form">
-            <b-row align-h="center" class="no-gutters">
-              <b-col cols="auto">
-                <h2 class="email-header">{{ closed && closed.header }}</h2>
-                <p>{{ closed && closed.subheader }}</p>
-              </b-col>
-            </b-row>
-            <b-row align-h="center">
-              <b-alert :show="msgShow" :variant="msgVariant" v-html="msgContent"></b-alert>
-            </b-row>
-            <b-row align-h="center">
-              <b-col cols="auto">
-                <b-button @click="onSubscribe" type="submit">Subscribe</b-button>
-              </b-col>
-            </b-row>
-          </b-container>
-        </page-section>
-      </strings-domain>
-      <b-row v-if="isOpen" class="justify-content-center info-session-interjection">
-        <strings-domain :value="content.infoSession" #key="{header, subheader, description}">
-          <b-col class="info-session-description" sm="12" md="4" md-offset="1">
-            <div class="header">{{ header }}</div>
-            <div class="subheader">{{ subheader }}</div>
-            <div class="description">{{ description }}</div>
+    <nova-hero
+      v-if="content.hero && isOpen"
+      :header="content.hero.header"
+      :subheader="content.hero.subheader"
+      :video="content.hero.video"
+      :lazy="content.hero.lazy"
+      :image="content.hero.image"
+      page="apply"
+    />
+    <nova-hero
+      v-else
+      :video="content.hero.video"
+      :lazy="content.hero.lazy"
+      :image="content.hero.image"
+      page="apply"
+    />
+    <page-section v-if="!isOpen">
+      <b-container class="email-form">
+        <b-row align-h="center" class="no-gutters">
+          <b-col cols="auto">
+            <h2 class="email-header">{{ content.hero.closed && content.hero.closed.header }}</h2>
+            <p>{{ content.hero.closed && content.hero.closed.subheader }}</p>
           </b-col>
-        </strings-domain>
-        <b-col class="info-session-details" sm="12" md="auto" md-offset="1">
-          <b-row class="h-100" align-h="center" align-v="center">
-            <b-col cols="auto">
-              <strings-domain :value="content.infoSessions">
-                <template #key="[session1, session2]">
-                  <div class="info-session h-50">
-                    <div class="time">{{ session1.time }}</div>
-                    <div class="location location-desktop">
-                      {{ `${session1.location}${session1.link && session1.link.url ? ' • ' : ''}` }}
-                      <template v-if="session1.link && session1.link.url">
-                        <a class="apply-link" :href="session1.link.url">{{ session1.link.text }}</a>
-                      </template>
-                    </div>
-                    <div class="location location-mobile">
-                      {{ `${session1.location}` }}
-                      <br />
-                      <a
-                        v-if="session1.link && session1.link.url"
-                        class="apply-link"
-                        :href="session1.link.url"
-                        >{{ session1.link.text }}</a
-                      >
-                    </div>
-                  </div>
-                  <div class="info-session h-50">
-                    <div class="time">{{ session2.time }}</div>
-                    <div class="location location-desktop">
-                      {{ `${session2.location}${session2.link && session2.link.url ? ' • ' : ''}` }}
-                      <a
-                        v-if="session2.link && session2.link.url"
-                        class="apply-link"
-                        :href="session2.link.url"
-                        >{{ session2.link.text }}</a
-                      >
-                    </div>
-                    <div class="location location-mobile">
-                      {{ `${session2.location}` }}
-                      <br />
-                      <a
-                        v-if="session2.link && session2.link.url"
-                        class="apply-link"
-                        :href="session2.link.url"
-                        >{{ session2.link.text }}</a
-                      >
-                    </div>
-                  </div>
-                </template>
-              </strings-domain>
-            </b-col>
-          </b-row>
-        </b-col>
-      </b-row>
-      <b-row v-if="isOpen" class="justify-content-center coffee-chat">
-        <b-col class="info-session-description" sm="12" md="4" md-offset="1">
-          <div class="header">Coffee Chats</div>
-          <div class="subheader">Spring 2021</div>
-          <div class="description">
-            Sign up to chat with some members on the team! You can learn more about what we do by
-            sending an email to any of the members on the spreadsheet.
-          </div>
-        </b-col>
-        <b-col class="info-session-details" sm="12" md="auto" md-offset="1">
-          <b-row class="h-100" align-h="center" align-v="center">
-            <b-col cols="auto">
-              <div class="info-session h-50">
-                <div class="time">
-                  Sign up at
-                  <a
-                    href="https://docs.google.com/spreadsheets/d/1xvFotNdMkCc4vaBv_LYTA8LHNIQfYlYaMIW3DUZYAvA/edit#gid=0"
-                  >
-                    this link
-                  </a>
-                  to chat!
-                </div>
-              </div>
-            </b-col>
-          </b-row>
-        </b-col>
-      </b-row>
-
-      <b-container>
-        <role-selector
-          class="application-role-selector"
-          v-model="roleId"
-          dropdownText="I want to apply for..."
-          :centered="true"
-          :bold="true"
-          :showAll="false"
-        />
-
-        <strings-domain v-for="child of sections" :key="child.id" :value="child.info">
-          <template #key="info">
-            <timeline-section v-if="info" :header="info.header" :rightHeader="info.rightHeader">
-              <template v-if="Array.isArray(info.sections)">
-                <div v-for="section of info.sections" :key="section.header">
-                  <template v-if="section">
-                    <div class="apply-header" v-if="section.header">{{ section.header }}</div>
-
-                    <div
-                      class="apply-list"
-                      v-if="section.content && Array.isArray(section.content.lines)"
-                    >
-                      <div
-                        class="apply-list-item"
-                        v-for="line of section.content.lines"
-                        :key="line"
-                      >
-                        {{ line }}
-                      </div>
-                    </div>
-                    <div class="apply-description" v-else>{{ section.content }}</div>
-                  </template>
-                </div>
-              </template>
-              <b-row v-else>
-                <b-col sm v-for="col of ['left', 'right']" :key="col">
-                  <template v-if="info.sections && info.sections[col]">
-                    <div class="apply-header">{{ info.sections[col].header }}</div>
-
-                    <div class="apply-list" v-if="info.sections[col].content.lines">
-                      <div
-                        class="apply-list-item"
-                        v-for="line of info.sections[col].content.lines"
-                        :key="line"
-                      >
-                        {{ line }}
-                      </div>
-                    </div>
-                    <div v-else class="apply-description">{{ info.sections[col].content }}</div>
-                  </template>
-                </b-col>
-              </b-row>
-              <strings-domain
-                v-if="isOpen"
-                #key="[primary, secondary]"
-                :value="[info['callToActionButton']]"
-              >
-                <b-row class="justify-content-center">
-                  <b-col cols="12">
-                    <b-row>
-                      <b-col v-if="primary && primary.link" md="auto" sm="12">
-                        <b-button
-                          :href="primary.link"
-                          size="lg"
-                          variant="primary"
-                          class="call-to-action-button text-start"
-                          >{{ primary.content }}</b-button
-                        >
-                      </b-col>
-                      <b-col v-if="secondary && secondary.link" md="auto" sm="12">
-                        <b-button
-                          :href="secondary.link"
-                          v-string="secondary.context"
-                          size="lg"
-                          variant="primary"
-                          class="call-to-action-button"
-                        ></b-button>
-                      </b-col>
-                    </b-row>
-                  </b-col>
-                </b-row>
-              </strings-domain>
-            </timeline-section>
-          </template>
-        </strings-domain>
+        </b-row>
+        <b-row align-h="center">
+          <b-alert :show="msgShow" :variant="msgVariant" v-html="msgContent"></b-alert>
+        </b-row>
+        <b-row align-h="center">
+          <b-col cols="auto">
+            <b-button @click="onSubscribe" type="submit">Subscribe</b-button>
+          </b-col>
+        </b-row>
       </b-container>
-    </strings-domain>
+    </page-section>
+    <b-row v-if="isOpen" class="justify-content-center info-session-interjection">
+      <b-col class="info-session-description" sm="12" md="4" md-offset="1">
+        <div class="header">{{ content.infoSession.header }}</div>
+        <div class="subheader">{{ content.infoSession.subheader }}</div>
+        <div class="description">{{ content.infoSession.description }}</div>
+      </b-col>
+      <b-col class="info-session-details" sm="12" md="auto" md-offset="1">
+        <b-row class="h-100" align-h="center" align-v="center">
+          <b-col cols="auto">
+            <div class="info-session h-50">
+              <div class="time">{{ session1.time }}</div>
+              <div class="location location-desktop">
+                {{ `${session1.location}${session1.link && session1.link.url ? ' • ' : ''}` }}
+                <template v-if="session1.link && session1.link.url">
+                  <a class="apply-link" :href="session1.link.url">{{ session1.link.text }}</a>
+                </template>
+              </div>
+              <div class="location location-mobile">
+                {{ `${session1.location}` }}
+                <br />
+                <a
+                  v-if="session1.link && session1.link.url"
+                  class="apply-link"
+                  :href="session1.link.url"
+                  >{{ session1.link.text }}</a
+                >
+              </div>
+            </div>
+            <div class="info-session h-50">
+              <div class="time">{{ session2.time }}</div>
+              <div class="location location-desktop">
+                {{ `${session2.location}${session2.link && session2.link.url ? ' • ' : ''}` }}
+                <a
+                  v-if="session2.link && session2.link.url"
+                  class="apply-link"
+                  :href="session2.link.url"
+                  >{{ session2.link.text }}</a
+                >
+              </div>
+              <div class="location location-mobile">
+                {{ `${session2.location}` }}
+                <br />
+                <a
+                  v-if="session2.link && session2.link.url"
+                  class="apply-link"
+                  :href="session2.link.url"
+                  >{{ session2.link.text }}</a
+                >
+              </div>
+            </div>
+          </b-col>
+        </b-row>
+      </b-col>
+    </b-row>
+    <b-row v-if="isOpen" class="justify-content-center coffee-chat">
+      <b-col class="info-session-description" sm="12" md="4" md-offset="1">
+        <div class="header">Coffee Chats</div>
+        <div class="subheader">Spring 2021</div>
+        <div class="description">
+          Sign up to chat with some members on the team! You can learn more about what we do by
+          sending an email to any of the members on the spreadsheet.
+        </div>
+      </b-col>
+      <b-col class="info-session-details" sm="12" md="auto" md-offset="1">
+        <b-row class="h-100" align-h="center" align-v="center">
+          <b-col cols="auto">
+            <div class="info-session h-50">
+              <div class="time">
+                Sign up at
+                <a
+                  href="https://docs.google.com/spreadsheets/d/1xvFotNdMkCc4vaBv_LYTA8LHNIQfYlYaMIW3DUZYAvA/edit#gid=0"
+                >
+                  this link
+                </a>
+                to chat!
+              </div>
+            </div>
+          </b-col>
+        </b-row>
+      </b-col>
+    </b-row>
+
+    <b-container>
+      <role-selector
+        class="application-role-selector"
+        v-model="roleId"
+        dropdownText="I want to apply for..."
+        :centered="true"
+        :bold="true"
+        :showAll="false"
+      />
+
+      <timeline-section
+        v-for="info of sections"
+        :key="info.id"
+        :header="info.header"
+        :rightHeader="info.rightHeader"
+      >
+        <div v-for="section of info.sections" :key="section.header">
+          <template v-if="section">
+            <div class="apply-header" v-if="section.header">{{ section.header }}</div>
+            <div class="apply-description">{{ section.content }}</div>
+          </template>
+        </div>
+        <b-row class="justify-content-center">
+          <b-col cols="12">
+            <b-row>
+              <b-col
+                v-if="info.callToActionButton && info.callToActionButton.link"
+                md="auto"
+                sm="12"
+              >
+                <b-button
+                  :href="info.callToActionButton.link"
+                  size="lg"
+                  variant="primary"
+                  class="call-to-action-button text-start"
+                  >{{ info.callToActionButton.content }}</b-button
+                >
+              </b-col>
+            </b-row>
+          </b-col>
+        </b-row>
+      </timeline-section>
+    </b-container>
     <dti-footer ref="footerRef" page="apply" />
   </page-background>
 </template>
@@ -218,7 +171,7 @@ import TimelineSection from '../components/TimelineSection.vue';
 import RoleSelector from '../components/RoleSelector.vue';
 import DtiFooter from '../components/DtiFooter.vue';
 
-import { ApplyContent, ApplicationInfo } from '../content';
+import { ApplyContent, Apply as ApplyType, InfoSessionElement } from '../content';
 import json from '../../data/pages/apply.json';
 
 interface Apply {
@@ -245,22 +198,35 @@ class Apply extends Vue {
     return json
   }
 
+  get isOpen(): boolean {
+    return this.content.joinInformation.applicationsOpen;
+  }
+
+  get session1(): InfoSessionElement {
+    return this.content.infoSessions[0]
+  }
+
+  get session2(): InfoSessionElement {
+    return this.content.infoSessions[0]
+  }
+
   onSubscribe(event: { preventDefault: () => void }): void {
     event.preventDefault();
     this.$refs.footerRef.subscriptionClick();
   }
 
-  get sections(): readonly { readonly id: string; readonly info: ApplicationInfo }[] {
+  get sections(): readonly (ApplyType & { id: string })[] {
     const info = this.content.applicationInfo.find(a => a.id === this.roleId);
 
     if (!info) {
       return [];
     }
 
-    return Object.keys(info).filter(id => id !== 'id').map(id => ({
-      id,
-      info: ((info as unknown) as { [id: string]: ApplicationInfo })[id] // TODO
-    }));
+    return [
+      { id: 'apply', ...info.apply },
+      { id: 'nextSteps', ...info.nextSteps },
+      { id: 'decision', ...info.decision }
+    ]
   }
 }
 

--- a/packages/website/src/views/Courses.vue
+++ b/packages/website/src/views/Courses.vue
@@ -1,15 +1,13 @@
 <template>
   <page-background>
-    <strings-domain :value="content.hero" #key="{ header, subheader, video, lazy, image}">
-      <nova-hero
-        :header="header"
-        :subheader="subheader"
-        :video="video"
-        :lazy="lazy"
-        :image="image"
-        page="courses"
-      />
-    </strings-domain>
+    <nova-hero
+      :header="content.hero.header"
+      :subheader="content.hero.subheader"
+      :video="content.hero.video"
+      :lazy="content.hero.lazy"
+      :image="content.hero.image"
+      page="courses"
+    />
     <b-container>
       <page-section>
         <template
@@ -35,24 +33,12 @@
               <div class="courses-row-content-subheader">
                 {{ content.subtitle }}
               </div>
-              <strings-domain
-                v-if="content.buttons"
-                #key="{apply, github}"
-                :value="content.buttons"
-              >
-                <b-button v-if="apply" class="social-button" :href="apply.link">
-                  <ApplyIcon />
-                  <div class="social-button-text">
-                    {{ apply.title || '' }}
-                  </div>
-                </b-button>
-                <b-button v-if="github" class="social-button" :href="github.link">
-                  <GitHubIcon />
-                  <div class="social-button-text">
-                    {{ github.title || '' }}
-                  </div>
-                </b-button>
-              </strings-domain>
+              <b-button class="social-button" :href="content.buttons.apply.link">
+                <ApplyIcon />
+                <div class="social-button-text">
+                  {{ content.buttons.apply.title || '' }}
+                </div>
+              </b-button>
             </b-col>
           </b-row>
           <b-row :key="content.id + 'desc'" align-h="center" align-v="center" class="courses-row">
@@ -290,17 +276,13 @@ $dark-gray: #4a4a4a;
 <script lang="ts">
 import Vue from 'vue';
 
-import GitHubIcon from '../assets/social/github.svg';
 import ApplyIcon from '../assets/other/apply.svg';
 
 import { CoursesContent } from '../content';
 import json from '../../data/pages/courses.json';
 
 export default Vue.extend({
-  components: {
-    GitHubIcon,
-    ApplyIcon
-  },
+  components: { ApplyIcon },
   computed: {
     content(): CoursesContent {
       return json;

--- a/packages/website/src/views/Initiatives.vue
+++ b/packages/website/src/views/Initiatives.vue
@@ -1,94 +1,72 @@
 <template>
   <page-background v-if="content">
-    <strings-domain :value="content.hero" #key="{ video, lazy, image}">
-      <nova-hero
-        header="Inspiring Change"
-        subheader="What sets us apart from other project teams is our desire to share what we learn with other students and members of the greater Ithaca community."
-        :video="video"
-        :lazy="lazy"
-        :image="image"
-        page="initiatives"
-      />
-    </strings-domain>
-    <strings-domain :value="content.promo" #key="{ makeathon, blueprint, halfbaked }">
-      <page-section class="initiatives-main-section">
-        <b-container>
-          <b-row align-h="center" align-v="center" class="initiative-row">
-            <b-col sm="12" md="7" class="initiative-row-img" order-md="2" order-sm="1">
-              <b-img class="initiative-row-image" :src="makeathon" />
-            </b-col>
-            <b-col
-              class="initiative-row-content-container"
-              sm="12"
-              md="5"
-              order-md="1"
-              order-sm="2"
-            >
-              <div class="initiative-row-content-header">Ready, Set, Make!</div>
-              <div class="initiative-row-content-subheader">Inspiring future generations.</div>
-              <p class="initiative-row-content">
-                Ready, Set, Make is an annual make-a-thon our team hosts for 5th and 6th grade
-                students! We invite students in the local community to Cornell and how they can use
-                design thinking to solve problems that they encounter. Their energy and creativity
-                was contagious, and team members and kids alike were building incredible prototypes
-                out of cardboard and craft supplies! DTI partnered with Makerspace to give an
-                introduction to 3D printing using Tinkercad.
-              </p>
-              <b-button class="social-button" href="https://medium.com/@alice.pham/5b9033aa7a6e">
-                <MediumIcon />
-                <div class="social-button-text">Read More</div>
-              </b-button>
-            </b-col>
-          </b-row>
-          <b-row align-h="center" align-v="center" class="initiative-row">
-            <b-col sm="12" md="7" class="initiative-row-img" order-md="1" order-sm="1">
-              <b-img class="initiative-row-image" :src="blueprint" />
-            </b-col>
-            <b-col
-              sm="12"
-              md="5"
-              class="initiative-row-content-container"
-              order-md="2"
-              order-sm="2"
-            >
-              <div class="initiative-row-content-header">DTI Blueprint</div>
-              <div class="initiative-row-content-subheader">Fostering Mentorship.</div>
-              <p class="initiative-row-content">
-                DTI Blueprint is a training program designed to teach students about design and
-                product thinking from team members’ own experience. Over several weeks, DTI team
-                members gave workshops on concepts like user research, product ideation, and minimum
-                viable products. Students formed groups and brainstormed a problem to solve on
-                campus and came up with a testable solution.
-              </p>
-            </b-col>
-          </b-row>
-          <b-row align-h="center" align-v="center" class="initiative-row">
-            <b-col sm="12" md="7" class="initiative-row-img" order-md="2" order-sm="1">
-              <b-img class="initiative-row-image" :src="halfbaked" />
-            </b-col>
-            <b-col
-              sm="12"
-              md="5"
-              class="initiative-row-content-container"
-              order-md="1"
-              order-sm="2"
-            >
-              <div class="initiative-row-content-header">Events &amp; Workshops</div>
-              <div class="initiative-row-content-subheader">Our presence on campus.</div>
-              <p class="initiative-row-content">
-                We are constantly trying to find ways to expand beyond our team and help the
-                community through holding workshops and events. In the past, we have held workshops
-                on UX Research, building a website portfolio, and more!
-              </p>
-              <b-button class="social-button" href="https://www.facebook.com/cornelldti/events/">
-                <FacebookIcon />
-                <div class="social-button-text">See Events</div>
-              </b-button>
-            </b-col>
-          </b-row>
-        </b-container>
-      </page-section>
-    </strings-domain>
+    <nova-hero
+      header="Inspiring Change"
+      subheader="What sets us apart from other project teams is our desire to share what we learn with other students and members of the greater Ithaca community."
+      :video="content.hero.video"
+      :lazy="content.hero.lazy"
+      :image="content.hero.image"
+      page="initiatives"
+    />
+    <page-section class="initiatives-main-section">
+      <b-container>
+        <b-row align-h="center" align-v="center" class="initiative-row">
+          <b-col sm="12" md="7" class="initiative-row-img" order-md="2" order-sm="1">
+            <b-img class="initiative-row-image" :src="content.promo.makeathon" />
+          </b-col>
+          <b-col class="initiative-row-content-container" sm="12" md="5" order-md="1" order-sm="2">
+            <div class="initiative-row-content-header">Ready, Set, Make!</div>
+            <div class="initiative-row-content-subheader">Inspiring future generations.</div>
+            <p class="initiative-row-content">
+              Ready, Set, Make is an annual make-a-thon our team hosts for 5th and 6th grade
+              students! We invite students in the local community to Cornell and how they can use
+              design thinking to solve problems that they encounter. Their energy and creativity was
+              contagious, and team members and kids alike were building incredible prototypes out of
+              cardboard and craft supplies! DTI partnered with Makerspace to give an introduction to
+              3D printing using Tinkercad.
+            </p>
+            <b-button class="social-button" href="https://medium.com/@alice.pham/5b9033aa7a6e">
+              <MediumIcon />
+              <div class="social-button-text">Read More</div>
+            </b-button>
+          </b-col>
+        </b-row>
+        <b-row align-h="center" align-v="center" class="initiative-row">
+          <b-col sm="12" md="7" class="initiative-row-img" order-md="1" order-sm="1">
+            <b-img class="initiative-row-image" :src="content.promo.blueprint" />
+          </b-col>
+          <b-col sm="12" md="5" class="initiative-row-content-container" order-md="2" order-sm="2">
+            <div class="initiative-row-content-header">DTI Blueprint</div>
+            <div class="initiative-row-content-subheader">Fostering Mentorship.</div>
+            <p class="initiative-row-content">
+              DTI Blueprint is a training program designed to teach students about design and
+              product thinking from team members’ own experience. Over several weeks, DTI team
+              members gave workshops on concepts like user research, product ideation, and minimum
+              viable products. Students formed groups and brainstormed a problem to solve on campus
+              and came up with a testable solution.
+            </p>
+          </b-col>
+        </b-row>
+        <b-row align-h="center" align-v="center" class="initiative-row">
+          <b-col sm="12" md="7" class="initiative-row-img" order-md="2" order-sm="1">
+            <b-img class="initiative-row-image" :src="content.promo.halfbaked" />
+          </b-col>
+          <b-col sm="12" md="5" class="initiative-row-content-container" order-md="1" order-sm="2">
+            <div class="initiative-row-content-header">Events &amp; Workshops</div>
+            <div class="initiative-row-content-subheader">Our presence on campus.</div>
+            <p class="initiative-row-content">
+              We are constantly trying to find ways to expand beyond our team and help the community
+              through holding workshops and events. In the past, we have held workshops on UX
+              Research, building a website portfolio, and more!
+            </p>
+            <b-button class="social-button" href="https://www.facebook.com/cornelldti/events/">
+              <FacebookIcon />
+              <div class="social-button-text">See Events</div>
+            </b-button>
+          </b-col>
+        </b-row>
+      </b-container>
+    </page-section>
     <dti-footer page="initiatives" />
   </page-background>
 </template>

--- a/packages/website/src/views/Projects.vue
+++ b/packages/website/src/views/Projects.vue
@@ -1,15 +1,13 @@
 <template>
   <page-background v-if="content">
-    <strings-domain :value="content.hero" #key="{ header, subheader, video, lazy, image}">
-      <nova-hero
-        :header="header"
-        :subheader="subheader"
-        :video="video"
-        :lazy="lazy"
-        :image="image"
-        page="projects"
-      />
-    </strings-domain>
+    <nova-hero
+      :header="content.hero.header"
+      :subheader="content.hero.subheader"
+      :video="content.hero.video"
+      :lazy="content.hero.lazy"
+      :image="content.hero.image"
+      page="projects"
+    />
 
     <page-section class="project-page-main-section">
       <b-row

--- a/packages/website/src/views/Sponsor.vue
+++ b/packages/website/src/views/Sponsor.vue
@@ -1,15 +1,13 @@
 <template>
   <page-background v-if="content">
-    <strings-domain :value="content.hero" #key="{ header, subheader, video, lazy, image}">
-      <nova-hero
-        :header="header"
-        :subheader="subheader"
-        :video="video"
-        :lazy="lazy"
-        :image="image"
-        page="sponsor"
-      />
-    </strings-domain>
+    <nova-hero
+      :header="content.hero.header"
+      :subheader="content.hero.subheader"
+      :video="content.hero.video"
+      :lazy="content.hero.lazy"
+      :image="content.hero.image"
+      page="sponsor"
+    />
     <b-container>
       <page-section>
         <b-row align-h="center" align-v="center" class="sponsor-row">

--- a/packages/website/src/views/Team.vue
+++ b/packages/website/src/views/Team.vue
@@ -1,105 +1,106 @@
 <template>
   <page-background v-if="content">
-    <strings-domain :value="content.hero" #key="{ header, subheader, video, lazy, image }">
-      <nova-hero
-        :header="header"
-        :subheader="subheader"
-        :video="video"
-        :lazy="lazy"
-        :image="image"
-        page="team"
-      />
+    <nova-hero
+      :header="content.hero.header"
+      :subheader="content.hero.subheader"
+      :video="content.hero.video"
+      :lazy="content.hero.lazy"
+      :image="content.hero.image"
+      page="team"
+    />
+    <div class="diversity diversity-background">
+      <!-- TODO bind formatting to actual elements-->
+      <b-row class="no-gutters diversity diversity-content">
+        <b-col sm="12" md="7" class="diversity-inner-left diversity-left-overlay">
+          <b-row>
+            <b-col sm="12" md="9">
+              <div class="team-header diversity-header my-auto">
+                {{ content.diversity.header }}
+              </div>
+              <div class="diversity-description my-auto lg-y-padding">
+                {{ content.diversity.description }}
+              </div>
 
-      <strings-domain #key="{ header, description, stats, gender }" :value="content.diversity">
-        <div class="diversity diversity-background">
-          <!-- TODO bind formatting to actual elements-->
-          <b-row class="no-gutters diversity diversity-content">
-            <b-col sm="12" md="7" class="diversity-inner-left diversity-left-overlay">
-              <b-row>
-                <b-col sm="12" md="9">
-                  <div class="team-header diversity-header my-auto">{{ header }}</div>
-                  <div class="diversity-description my-auto lg-y-padding">{{ description }}</div>
+              <h3 class="graph-header lg-y-padding">{{ content.diversity.gender.header }}</h3>
 
-                  <h3 class="graph-header lg-y-padding">{{ gender.header }}</h3>
-
-                  <b-row class="lg-y-padding" align-h="center">
-                    <b-col cols="auto">
-                      <circle-progress-indicator :percentage="femalePercentage(divRoleId)">
-                        <div class="text-center graph-data h-100">
-                          <b-row align-v="center" class="h-100">
-                            <b-col cols="6" class="graph-datum">
-                              <h3 v-text="`${Math.round(100 * malePercentage(divRoleId))}%`" />
-                              <p class="graph-datum-description">Male</p>
-                            </b-col>
-                            <b-col cols="6" class="graph-datum red">
-                              <h3 v-text="`${Math.round(100 * femalePercentage(divRoleId))}%`" />
-                              <p class="graph-datum-description">Female</p>
-                            </b-col>
-                          </b-row>
-                        </div>
-                      </circle-progress-indicator>
-                    </b-col>
-                  </b-row>
-                  <b-row class="my-auto" align-h="center">
-                    <b-col>
-                      <role-selector
-                        class="diversity-role-selector"
-                        :centered="true"
-                        v-model="divRoleId"
-                        :dark="true"
-                        density="compact"
-                      />
-                    </b-col>
-                  </b-row>
+              <b-row class="lg-y-padding" align-h="center">
+                <b-col cols="auto">
+                  <circle-progress-indicator :percentage="femalePercentage(divRoleId)">
+                    <div class="text-center graph-data h-100">
+                      <b-row align-v="center" class="h-100">
+                        <b-col cols="6" class="graph-datum">
+                          <h3 v-text="`${Math.round(100 * malePercentage(divRoleId))}%`" />
+                          <p class="graph-datum-description">Male</p>
+                        </b-col>
+                        <b-col cols="6" class="graph-datum red">
+                          <h3 v-text="`${Math.round(100 * femalePercentage(divRoleId))}%`" />
+                          <p class="graph-datum-description">Female</p>
+                        </b-col>
+                      </b-row>
+                    </div>
+                  </circle-progress-indicator>
                 </b-col>
-                <b-col sm="0" md="3"></b-col>
               </b-row>
-            </b-col>
-            <b-col sm="12" md="4" align-self="center" class="diversity-inner-right mx-auto">
-              <b-row>
-                <b-col cols="12" class="diversity-description diversity-inner-text">
-                  <div class="diversity-stat-header">{{ stats.underclassmen.stat }}</div>
-                  <div class="diversity-description diversity-stat-description">
-                    {{ stats.underclassmen.description }}
-                  </div>
-                </b-col>
-                <b-col cols="12" class="diversity-description diversity-inner-text">
-                  <div class="diversity-stat-header">{{ stats.majors.stat }}</div>
-                  <div class="diversity-description diversity-stat-description">
-                    {{ stats.majors.description }}
-                  </div>
-                </b-col>
-                <b-col cols="12" class="diversity-description diversity-inner-text">
-                  <div class="diversity-stat-header">{{ stats.colleges.stat }}</div>
-                  <div class="diversity-description diversity-stat-description">
-                    {{ stats.colleges.description }}
-                  </div>
+              <b-row class="my-auto" align-h="center">
+                <b-col>
+                  <role-selector
+                    class="diversity-role-selector"
+                    :centered="true"
+                    v-model="divRoleId"
+                    :dark="true"
+                    density="compact"
+                  />
                 </b-col>
               </b-row>
             </b-col>
+            <b-col sm="0" md="3"></b-col>
           </b-row>
-        </div>
-      </strings-domain>
-
-      <b-container fluid>
-        <page-section>
-          <div class="team-header diversity-header">{{ content.team.header }}</div>
-
-          <!-- TODO actual padding -->
-          <br />
-
-          <b-row align-h="center">
-            <b-col cols="12">
-              <role-selector density="normal" class="team-role-selector" v-model="roleId" />
-
-              <headshot-grid
-                :members="[...filterMembers(roleId, true), ...filterMembers(roleId)]"
-              />
+        </b-col>
+        <b-col sm="12" md="4" align-self="center" class="diversity-inner-right mx-auto">
+          <b-row>
+            <b-col cols="12" class="diversity-description diversity-inner-text">
+              <div class="diversity-stat-header">
+                {{ content.diversity.stats.underclassmen.stat }}
+              </div>
+              <div class="diversity-description diversity-stat-description">
+                {{ content.diversity.stats.underclassmen.description }}
+              </div>
+            </b-col>
+            <b-col cols="12" class="diversity-description diversity-inner-text">
+              <div class="diversity-stat-header">{{ content.diversity.stats.majors.stat }}</div>
+              <div class="diversity-description diversity-stat-description">
+                {{ content.diversity.stats.majors.description }}
+              </div>
+            </b-col>
+            <b-col cols="12" class="diversity-description diversity-inner-text">
+              <div class="diversity-stat-header">
+                {{ content.diversity.stats.colleges.stat }}
+              </div>
+              <div class="diversity-description diversity-stat-description">
+                {{ content.diversity.stats.colleges.description }}
+              </div>
             </b-col>
           </b-row>
-        </page-section>
-      </b-container>
-    </strings-domain>
+        </b-col>
+      </b-row>
+    </div>
+
+    <b-container fluid>
+      <page-section>
+        <div class="team-header diversity-header">{{ content.team.header }}</div>
+
+        <!-- TODO actual padding -->
+        <br />
+
+        <b-row align-h="center">
+          <b-col cols="12">
+            <role-selector density="normal" class="team-role-selector" v-model="roleId" />
+
+            <headshot-grid :members="[...filterMembers(roleId, true), ...filterMembers(roleId)]" />
+          </b-col>
+        </b-row>
+      </page-section>
+    </b-container>
 
     <dti-footer page="team" />
   </page-background>


### PR DESCRIPTION
## Summary

~~`strings-domain` is an existing component that does something equivalent to JS's `with`:~~

~~const obj = { foo: 2, bar: 3}~~
~~with (obj) { // destruct obj and make every field in scope~~
~~console.log(foo + bar) // 5 is logged~~
~~}~~

~~Use of `width` is banned by almost all linters by default, so we should also not using components with similar mechanism.~~

The `strings-domain` component also doesn't work well with TS and results in many red squiggly lines. There is currently no way in Vue 2 to make this well typed, because the slots are not part of the type signature of vue components, so there is no way to communicate to the type system that the type of the prop `value` is linked to the type of the named slot `key`.

In this PR, I removed them all and just replaced them with normal field access. As a result, the code should be more readable, and it should be more obvious what kind of data we are using from the json.

## Note

This PR also removes support for linking medium article in the project page, because no project is using it and it probably won't be used later as well.

## Test Plan

Screenshots to show that the website is still working:

<img width="1730" alt="Screen Shot 2021-02-26 at 18 50 34" src="https://user-images.githubusercontent.com/4290500/109367479-353a2d80-7864-11eb-8a75-886a6ee7932e.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 50 37" src="https://user-images.githubusercontent.com/4290500/109367480-35d2c400-7864-11eb-93c0-c97626e0c68d.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 50 41" src="https://user-images.githubusercontent.com/4290500/109367481-366b5a80-7864-11eb-92d8-0924bf661525.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 50 48" src="https://user-images.githubusercontent.com/4290500/109367483-3703f100-7864-11eb-9d39-594220e9288c.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 50 52" src="https://user-images.githubusercontent.com/4290500/109367484-3703f100-7864-11eb-8719-cf4f1dfa81f7.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 50 58" src="https://user-images.githubusercontent.com/4290500/109367485-379c8780-7864-11eb-8cd0-09c0a19f193d.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 02" src="https://user-images.githubusercontent.com/4290500/109367486-379c8780-7864-11eb-81bc-65839d5d08c4.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 05" src="https://user-images.githubusercontent.com/4290500/109367489-38351e00-7864-11eb-9cd6-f1be96c9b56c.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 10" src="https://user-images.githubusercontent.com/4290500/109367490-38cdb480-7864-11eb-85af-86bea1d179de.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 12" src="https://user-images.githubusercontent.com/4290500/109367493-38cdb480-7864-11eb-94a0-c06a0f009377.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 16" src="https://user-images.githubusercontent.com/4290500/109367494-39664b00-7864-11eb-9209-71a59e4a27bb.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 18" src="https://user-images.githubusercontent.com/4290500/109367495-39664b00-7864-11eb-8934-2f7b4678efde.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 20" src="https://user-images.githubusercontent.com/4290500/109367496-39fee180-7864-11eb-8bc1-47c4ba6a5e68.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 25" src="https://user-images.githubusercontent.com/4290500/109367497-39fee180-7864-11eb-96f1-ac110b6393d8.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 28" src="https://user-images.githubusercontent.com/4290500/109367499-3a977800-7864-11eb-8c6d-c4cd3f42cd0a.png">
<img width="1730" alt="Screen Shot 2021-02-26 at 18 51 30" src="https://user-images.githubusercontent.com/4290500/109367500-3a977800-7864-11eb-9fef-0c4be6a502cf.png">
