### PR TITLE
[easy] Remove all leftover admin config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,3 @@ s3/
 .temp
 .cache
 
-# CMS folders
-admin/lib/**/*

--- a/packages/website/gridsome.server.js
+++ b/packages/website/gridsome.server.js
@@ -5,19 +5,10 @@
 // Changes here require a server restart.
 // To restart press CTRL + C in terminal and run `gridsome develop`
 
-const express = require('express');
-const path = require('path');
-
-const $AssetsJSON = require("./data/assets.json");
+const $AssetsJSON = require('./data/assets.json');
 
 /** @type import('@tyankatsu0105/types-gridsome').Server */
-module.exports = function (api) {
-  // for gridsome develop
-  api.configureServer(app => {
-    // webpack won't host these files in development mode.
-    app.use('/admin', express.static(path.resolve(__dirname, '../../dist/admin/')));
-  });
-
+module.exports = api => {
   api.loadSource(({ addSchemaTypes, addMetadata }) => {
     // Define the member schema.
 
@@ -47,4 +38,4 @@ module.exports = function (api) {
       addMetadata(k, v);
     });
   });
-}
+};

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -18,13 +18,6 @@
     "lib": ["esnext", "dom", "dom.iterable", "scripthost"],
     "outDir": "dist"
   },
-  "include": [
-    "admin/**/*.js",
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "src/**/*.vue",
-    "tests/**/*.ts",
-    "tests/**/*.tsx"
-  ],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "tests/**/*.ts", "tests/**/*.tsx"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary

CMS is gone, so no need for the admin path config. (CMS used to be under `/admin`)

## Test Plan

Things build on CI.